### PR TITLE
20170323: 添加FusionCDN的几个函数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,3 @@ CUnit/doc/headers/Makefile
 CUnit/libtool
 CUnit/stamp-h1
 
-CMakeCache.txt
-CMakeFiles/
-cmake_install.cmake
-lib/libqiniu.a
-curl/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   - `GetBandwidthData`
   
   - `GetLogList`
+  
+- **io**新增PutStream
+
+- 新增put_strem和cdn示例代码
 
 ### v6.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## CHANGE LOG
 
+### v7.x?
+
+>从[github/BluntBlade/20170111.timestamp_token](https://github.com/bluntblade/c-sdk/tree/20170111.timestamp_token)这个分支代码修改而来。
+
+- **http**新增Qiniu_Client_CallWithBuffer2
+
+- **CDN**新增功能：
+
+  - `RefreshUrls`
+  
+  - `RefreshDirs`
+  
+  - `PrefetchUrls`
+  
+  - `GetFluxData`
+  
+  - `GetBandwidthData`
+  
+  - `GetLogList`
+
 ### v6.2.4
 
 - 单元测试调整

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,77 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required (VERSION 3.3.1)
+project (libqiniu)
 
-add_definitions(-Wall)
-add_definitions(-Wno-deprecated)
-add_definitions(-O2)
-add_definitions(-g)
+set (BUILD_SHARED_LIBS ON CACHE BOOL "Set to ON to build shared or dll libraries (default: ON)")
+set (BUILD_STATIC_LIBS OFF CACHE BOOL "Set to ON to build static libraries (default: OFF)")
+set (BUILD_X86_PLATFORM OFF CACHE BOOL "Set to ON to build for x86 platform (default: OFF)")
+set (FUNCTION_LEVEL_LINKING OFF CACHE BOOL "Set to ON to place every function in its own section to garbadge-collect unreferenced ones")
 
-#头文件引用地址中
-#curl的地址请根据开发机器上的实际地址修改
-include_directories(./
-	./b64
-        ./cJSON
-        ./qiniu
-	./curl
-        )
+file (GLOB_RECURSE MY_SOURCE_FILES qiniu/*.c b64/*.c cJSON/*.c)
+include_directories (qiniu b64 cJSON)
 
-aux_source_directory(./b64 SRCS1)
-aux_source_directory(./cJSON SRCS2)
-aux_source_directory(./qiniu SRCS3)
-add_library(qiniu STATIC ${SRCS1} ${SRCS2} ${SRCS3})
+### Platform Settings
 
-SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+set (MY_COMPILE_DEFINITIONS "")
+set (MY_COMPILE_FLAGS "")
+
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+
+    ## Append platform-dependent source files
+    file (GLOB_RECURSE MY_WINDOWS_SOURCE_FILES windows/*.c)
+    list (APPEND MY_SOURCE_FILES ${MY_WINDOWS_SOURCE_FILES})
+    include_directories (windows)
+
+    set (LOCAL_PACKAGE_PATH "C:/packages" CACHE PATH "Set to the path where dependent libraries (openssl / curl, etc) reside")
+    include_directories (${LOCAL_PACKAGE_PATH}/include SYSTEM)
+    link_directories (${LOCAL_PACKAGE_PATH}/lib)
+
+    if (DEFINED BUILD_SHARED_LIBS AND ${BUILD_SHARED_LIBS})
+        list (APPEND MY_COMPILE_DEFINITIONS COMPILING_QINIU_LIBRARY_DLL)
+    endif (DEFINED BUILD_SHARED_LIBS AND ${BUILD_SHARED_LIBS})
+
+else ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+
+    include_directories (/usr/include /usr/local/include SYSTEM)
+    link_directories (/usr/lib /usr/local/lib)
+
+    set (MY_LINKING_LIBRARIES curl crypto)
+
+    list (APPEND MY_COMPILE_FLAGS -Wall)
+
+    if (DEFINED FUNCTION_LEVEL_LINKING AND ${FUNCTION_LEVEL_LINKING})
+        list (APPEND MY_COMPILE_FLAGS -ffunction-sections)
+    endif (DEFINED FUNCTION_LEVEL_LINKING AND ${FUNCTION_LEVEL_LINKING})
+
+endif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+
+if (DEFINED BUILD_X86_PLATFORM AND ${BUILD_X86_PLATFORM})
+    list (APPEND CMAKE_C_FLAGS "-m32")
+endif (DEFINED BUILD_X86_PLATFORM AND ${BUILD_X86_PLATFORM})
+
+### Target Settings
+
+if (DEFINED BUILD_SHARED_LIBS AND ${BUILD_SHARED_LIBS})
+
+    add_library (qiniu SHARED ${MY_SOURCE_FILES})
+    
+    if (NOT ("X${MY_LINKING_LIBRARIES}" STREQUAL "X"))
+        target_link_libraries (qiniu ${MY_LINKING_LIBRARIES})
+    endif (NOT ("X${MY_LINKING_LIBRARIES}" STREQUAL "X"))
+
+endif (DEFINED BUILD_SHARED_LIBS AND ${BUILD_SHARED_LIBS})
+
+if (DEFINED BUILD_STATIC_LIBS AND ${BUILD_STATIC_LIBS})
+
+    add_library (qiniu_a STATIC ${MY_SOURCE_FILES})
+
+endif (DEFINED BUILD_STATIC_LIBS AND ${BUILD_STATIC_LIBS})
+
+if (NOT ("X${MY_COMPILE_FLAGS}" STREQUAL "X"))
+    set_target_properties (qiniu PROPERTIES COMPILE_FLAGS "${MY_COMPILE_FLAGS}")
+endif (NOT ("X${MY_COMPILE_FLAGS}" STREQUAL "X"))
+
+if (NOT ("X${MY_COMPILE_DEFINITIONS}" STREQUAL "X"))
+    set_target_properties (qiniu PROPERTIES COMPILE_DEFINITIONS ${MY_COMPILE_DEFINITIONS})
+endif (NOT ("X${MY_COMPILE_DEFINITIONS}" STREQUAL "X"))
+
+add_subdirectory (demo)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,0 @@
-all:
-	cd docs/gist; make
-
-test:
-	cd tests; make test
-
-install: all
-	cp qiniu/*.h ../c-sdk-for-windows/include/qiniu/
-

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,0 +1,29 @@
+add_executable (put_file put_file.c)
+target_link_libraries (put_file qiniu crypto m)
+
+add_executable (put_stream put_stream.c)
+target_link_libraries (put_stream qiniu crypto m)
+
+add_executable (cdn_refresh cdn_refresh.c)
+target_link_libraries (cdn_refresh qiniu crypto m)
+
+add_executable (cdn_prefetch cdn_prefetch.c)
+target_link_libraries (cdn_prefetch qiniu crypto m)
+
+add_executable (cdn_flux cdn_flux.c)
+target_link_libraries (cdn_flux qiniu crypto m)
+
+add_executable (cdn_bandwidth cdn_bandwidth.c)
+target_link_libraries (cdn_bandwidth qiniu crypto m)
+
+add_executable (cdn_loglist cdn_loglist.c)
+target_link_libraries (cdn_loglist qiniu crypto m)
+
+add_executable (demo demo.c)
+target_link_libraries (demo qiniu crypto m)
+
+add_executable (put_file_abortable put_file_abortable.c)
+target_link_libraries (put_file_abortable qiniu crypto m)
+
+add_executable (gen_download_url_with_deadline gen_download_url_with_deadline.c)
+target_link_libraries (gen_download_url_with_deadline qiniu crypto m)

--- a/demo/cdn_bandwidth.c
+++ b/demo/cdn_bandwidth.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../qiniu/http.h"
+#include "../qiniu/cdn.h"
+
+int main(int argc, char * argv[])
+{
+	Qiniu_Error err;
+	Qiniu_Client cli;
+	Qiniu_Mac mac;
+    Qiniu_Cdn_FluxBandwidthRet ret;
+
+	Qiniu_Global_Init(0);
+	Qiniu_Servend_Init(0);
+	Qiniu_MacAuth_Init();
+
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+
+    char* startDate = "2017-01-01";
+    char* endDate = "2017-01-02";
+    char* granularity = "day";
+    char* domains[2] = {"a.com","b.com"};
+
+	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
+
+    err = Qiniu_Cdn_GetBandwidthData(&cli,&ret,startDate,endDate,granularity,domains,2);
+
+	printf("code:%d\n msg:%s\n", err.code, err.message);
+
+	if (err.code == 200) {
+		printf("-----------------------------------------\n");
+		printf(" code : %d\n", ret.code);
+		printf("error : %s\n", ret.error);
+        printf(" time : %s\n", ret.time);
+		printf(" data : %s\n", ret.data);
+		printf("-----------------------------------------\n");
+	}
+
+	Qiniu_Client_Cleanup(&cli);
+	//Qiniu_MacAuth_Cleanup();
+	Qiniu_Servend_Cleanup();
+	Qiniu_Global_Cleanup();
+
+	return 0;
+} // main

--- a/demo/cdn_bandwidth.c
+++ b/demo/cdn_bandwidth.c
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
 	Qiniu_Error err;
 	Qiniu_Client cli;
 	Qiniu_Mac mac;
-	Qiniu_Cdn_FluxBandwidthRet ret;
+	Qiniu_Cdn_BandwidthRet ret;
 
 	Qiniu_Global_Init(0);
 	Qiniu_Servend_Init(0);
@@ -17,8 +17,8 @@ int main(int argc, char * argv[])
 	mac.accessKey = argv[1];
 	mac.secretKey = argv[2];
 
-	char* startDate = "2017-01-01";
-	char* endDate = "2017-01-02";
+	char* startDate = "2017-03-28";
+	char* endDate = "2017-03-29";
 	char* granularity = "day";
 	char* domains[2] = { "a.com","b.com" };
 
@@ -28,14 +28,26 @@ int main(int argc, char * argv[])
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 
-	if (err.code == 200) {
-		printf("-----------------------------------------\n");
-		printf(" code : %d\n", ret.code);
-		printf("error : %s\n", ret.error);
-		printf(" time : %s\n", ret.time);
-		printf(" data : %s\n", ret.data);
-		printf("-----------------------------------------\n");
+	printf("---------------------------------------------------------------------\n");
+	printf(" code : %d\n", ret.code);
+	printf("error : %s\n", ret.error);
+	printf("  num : %d\n", ret.num);
+	for (int i = 0; i < ret.num; ++i) {
+		if (ret.data_a[i].hasValue) {
+			printf("\ndomain : %s\n", ret.data_a[i].domain);
+			printf("#\t\ttime\t\tchina\t\toversea\n");
+			for (int j = 0; j < ret.data_a[i].count; ++j) {
+				printf("%d\t%s\t%d\t\t%d\n",
+					j + 1,
+					ret.data_a[i].item_a[j].time,
+					ret.data_a[i].item_a[j].val_china,
+					ret.data_a[i].item_a[j].val_oversea);
+			}
+		}
 	}
+	printf("---------------------------------------------------------------------\n");
+
+	Qiniu_Free_CdnBandwidthRet(&ret);
 
 	Qiniu_Client_Cleanup(&cli);
 	//Qiniu_MacAuth_Cleanup();

--- a/demo/cdn_bandwidth.c
+++ b/demo/cdn_bandwidth.c
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
 	Qiniu_Error err;
 	Qiniu_Client cli;
 	Qiniu_Mac mac;
-    Qiniu_Cdn_FluxBandwidthRet ret;
+	Qiniu_Cdn_FluxBandwidthRet ret;
 
 	Qiniu_Global_Init(0);
 	Qiniu_Servend_Init(0);
@@ -17,14 +17,14 @@ int main(int argc, char * argv[])
 	mac.accessKey = argv[1];
 	mac.secretKey = argv[2];
 
-    char* startDate = "2017-01-01";
-    char* endDate = "2017-01-02";
-    char* granularity = "day";
-    char* domains[2] = {"a.com","b.com"};
+	char* startDate = "2017-01-01";
+	char* endDate = "2017-01-02";
+	char* granularity = "day";
+	char* domains[2] = { "a.com","b.com" };
 
 	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
 
-    err = Qiniu_Cdn_GetBandwidthData(&cli,&ret,startDate,endDate,granularity,domains,2);
+	err = Qiniu_Cdn_GetBandwidthData(&cli, &ret, startDate, endDate, granularity, domains, 2);
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 
@@ -32,7 +32,7 @@ int main(int argc, char * argv[])
 		printf("-----------------------------------------\n");
 		printf(" code : %d\n", ret.code);
 		printf("error : %s\n", ret.error);
-        printf(" time : %s\n", ret.time);
+		printf(" time : %s\n", ret.time);
 		printf(" data : %s\n", ret.data);
 		printf("-----------------------------------------\n");
 	}

--- a/demo/cdn_flux.c
+++ b/demo/cdn_flux.c
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
 	Qiniu_Error err;
 	Qiniu_Client cli;
 	Qiniu_Mac mac;
-    Qiniu_Cdn_FluxBandwidthRet ret;
+	Qiniu_Cdn_FluxBandwidthRet ret;
 
 	Qiniu_Global_Init(0);
 	Qiniu_Servend_Init(0);
@@ -17,14 +17,14 @@ int main(int argc, char * argv[])
 	mac.accessKey = argv[1];
 	mac.secretKey = argv[2];
 
-    char* startDate = "2017-01-01";
-    char* endDate = "2017-01-02";
-    char* granularity = "day";
-    char* domains[2] = {"a.com","b.com"};
+	char* startDate = "2017-01-01";
+	char* endDate = "2017-01-02";
+	char* granularity = "day";
+	char* domains[2] = { "a.com","b.com" };
 
 	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
 
-    err = Qiniu_Cdn_GetFluxData(&cli,&ret,startDate,endDate,granularity,domains,2);
+	err = Qiniu_Cdn_GetFluxData(&cli, &ret, startDate, endDate, granularity, domains, 2);
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 
@@ -32,7 +32,7 @@ int main(int argc, char * argv[])
 		printf("-----------------------------------------\n");
 		printf(" code : %d\n", ret.code);
 		printf("error : %s\n", ret.error);
-        printf(" time : %s\n", ret.time);
+		printf(" time : %s\n", ret.time);
 		printf(" data : %s\n", ret.data);
 		printf("-----------------------------------------\n");
 	}

--- a/demo/cdn_flux.c
+++ b/demo/cdn_flux.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../qiniu/http.h"
+#include "../qiniu/cdn.h"
+
+int main(int argc, char * argv[])
+{
+	Qiniu_Error err;
+	Qiniu_Client cli;
+	Qiniu_Mac mac;
+    Qiniu_Cdn_FluxBandwidthRet ret;
+
+	Qiniu_Global_Init(0);
+	Qiniu_Servend_Init(0);
+	Qiniu_MacAuth_Init();
+
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+
+    char* startDate = "2017-01-01";
+    char* endDate = "2017-01-02";
+    char* granularity = "day";
+    char* domains[2] = {"a.com","b.com"};
+
+	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
+
+    err = Qiniu_Cdn_GetFluxData(&cli,&ret,startDate,endDate,granularity,domains,2);
+
+	printf("code:%d\n msg:%s\n", err.code, err.message);
+
+	if (err.code == 200) {
+		printf("-----------------------------------------\n");
+		printf(" code : %d\n", ret.code);
+		printf("error : %s\n", ret.error);
+        printf(" time : %s\n", ret.time);
+		printf(" data : %s\n", ret.data);
+		printf("-----------------------------------------\n");
+	}
+
+	Qiniu_Client_Cleanup(&cli);
+	//Qiniu_MacAuth_Cleanup();
+	Qiniu_Servend_Cleanup();
+	Qiniu_Global_Cleanup();
+
+	return 0;
+} // main

--- a/demo/cdn_flux.c
+++ b/demo/cdn_flux.c
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
 	Qiniu_Error err;
 	Qiniu_Client cli;
 	Qiniu_Mac mac;
-	Qiniu_Cdn_FluxBandwidthRet ret;
+	Qiniu_Cdn_FluxRet ret;
 
 	Qiniu_Global_Init(0);
 	Qiniu_Servend_Init(0);
@@ -17,8 +17,8 @@ int main(int argc, char * argv[])
 	mac.accessKey = argv[1];
 	mac.secretKey = argv[2];
 
-	char* startDate = "2017-01-01";
-	char* endDate = "2017-01-02";
+	char* startDate = "2017-03-28";
+	char* endDate = "2017-03-28";
 	char* granularity = "day";
 	char* domains[2] = { "a.com","b.com" };
 
@@ -28,14 +28,26 @@ int main(int argc, char * argv[])
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 
-	if (err.code == 200) {
-		printf("-----------------------------------------\n");
-		printf(" code : %d\n", ret.code);
-		printf("error : %s\n", ret.error);
-		printf(" time : %s\n", ret.time);
-		printf(" data : %s\n", ret.data);
-		printf("-----------------------------------------\n");
+	printf("---------------------------------------------------------------------\n");
+	printf(" code : %d\n", ret.code);
+	printf("error : %s\n", ret.error);
+	printf("  num : %d\n", ret.num);
+	for (int i = 0; i < ret.num; ++i) {
+		if (ret.data_a[i].hasValue != FALSE) {
+			printf("\ndomain : %s\n", ret.data_a[i].domain);
+			printf("#\t\ttime\t\tchina\t\toversea\n");
+			for (int j = 0; j < ret.data_a[i].count; ++j) {
+				printf("%d\t%s\t%d\t%d\n",
+					j + 1,
+					ret.data_a[i].item_a[j].time,
+					ret.data_a[i].item_a[j].val_china,
+					ret.data_a[i].item_a[j].val_oversea);
+			}
+		}
 	}
+	printf("---------------------------------------------------------------------\n");
+
+	Qiniu_Free_CdnFluxRet(&ret);
 
 	Qiniu_Client_Cleanup(&cli);
 	//Qiniu_MacAuth_Cleanup();

--- a/demo/cdn_loglist.c
+++ b/demo/cdn_loglist.c
@@ -17,7 +17,7 @@ int main(int argc, char * argv[])
 	mac.accessKey = argv[1];
 	mac.secretKey = argv[2];
 
-	char* day = "2017-01-01";
+	char* day = "2017-03-28";
 	char* domains[2] = { "a.com","b.com" };
 
 	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
@@ -26,13 +26,29 @@ int main(int argc, char * argv[])
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 
-	if (err.code == 200) {
-		printf("-----------------------------------------\n");
-		printf(" code : %d\n", ret.code);
-		printf("error : %s\n", ret.error);
-		printf(" data : %s\n", ret.data);
-		printf("-----------------------------------------\n");
+	printf("---------------------------------------------------\n");
+	printf(" code : %d\n", ret.code);
+	printf("error : %s\n", ret.error);
+	printf("  num : %d\n", ret.num);
+	for (int i = 0; i < ret.num; ++i) {
+		if (ret.data_a[i].hasValue) {
+			printf("\n");
+			printf("  index : %d/%d\n", i + 1, ret.num);
+			printf(" domain : %s\n\n", ret.data_a[i].domain);
+			for (int j = 0; j < ret.data_a[i].count; ++j) {
+				printf("   part : %d/%d\n", j + 1, ret.data_a[i].count);
+				printf("   name : %s\n", ret.data_a[i].item_a[j].name);
+				printf("   size : %d\n", ret.data_a[i].item_a[j].size);
+				printf("  mtime : %d\n", ret.data_a[i].item_a[j].mtime);
+				printf("    url : %s\n", ret.data_a[i].item_a[j].url);
+				printf("\n");
+			}
+			printf("\n");
+		}
 	}
+	printf("---------------------------------------------------\n");
+
+	Qiniu_Free_CdnLogListRet(&ret);
 
 	Qiniu_Client_Cleanup(&cli);
 	//Qiniu_MacAuth_Cleanup();

--- a/demo/cdn_loglist.c
+++ b/demo/cdn_loglist.c
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
 	Qiniu_Error err;
 	Qiniu_Client cli;
 	Qiniu_Mac mac;
-    Qiniu_Cdn_LogListRet ret;
+	Qiniu_Cdn_LogListRet ret;
 
 	Qiniu_Global_Init(0);
 	Qiniu_Servend_Init(0);
@@ -17,22 +17,22 @@ int main(int argc, char * argv[])
 	mac.accessKey = argv[1];
 	mac.secretKey = argv[2];
 
-    char* day = "2017-01-01";
-    char* domains[2] = {"a.com","b.com"};
+	char* day = "2017-01-01";
+	char* domains[2] = { "a.com","b.com" };
 
 	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
 
-    err = Qiniu_Cdn_GetLogList(&cli,&ret,day,domains,2);
+	err = Qiniu_Cdn_GetLogList(&cli, &ret, day, domains, 2);
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 
-	//if (err.code == 200) {
+	if (err.code == 200) {
 		printf("-----------------------------------------\n");
 		printf(" code : %d\n", ret.code);
 		printf("error : %s\n", ret.error);
 		printf(" data : %s\n", ret.data);
 		printf("-----------------------------------------\n");
-	//}
+	}
 
 	Qiniu_Client_Cleanup(&cli);
 	//Qiniu_MacAuth_Cleanup();

--- a/demo/cdn_loglist.c
+++ b/demo/cdn_loglist.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../qiniu/http.h"
+#include "../qiniu/cdn.h"
+
+int main(int argc, char * argv[])
+{
+	Qiniu_Error err;
+	Qiniu_Client cli;
+	Qiniu_Mac mac;
+    Qiniu_Cdn_LogListRet ret;
+
+	Qiniu_Global_Init(0);
+	Qiniu_Servend_Init(0);
+	Qiniu_MacAuth_Init();
+
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+
+    char* day = "2017-01-01";
+    char* domains[2] = {"a.com","b.com"};
+
+	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
+
+    err = Qiniu_Cdn_GetLogList(&cli,&ret,day,domains,2);
+
+	printf("code:%d\n msg:%s\n", err.code, err.message);
+
+	//if (err.code == 200) {
+		printf("-----------------------------------------\n");
+		printf(" code : %d\n", ret.code);
+		printf("error : %s\n", ret.error);
+		printf(" data : %s\n", ret.data);
+		printf("-----------------------------------------\n");
+	//}
+
+	Qiniu_Client_Cleanup(&cli);
+	//Qiniu_MacAuth_Cleanup();
+	Qiniu_Servend_Cleanup();
+	Qiniu_Global_Cleanup();
+
+	return 0;
+} // main

--- a/demo/cdn_prefetch.c
+++ b/demo/cdn_prefetch.c
@@ -25,17 +25,18 @@ int main(int argc, char * argv[])
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 
-	if (err.code == 200) {
-		printf("-----------------------------------------\n");
-		printf("      code : %d\n", ret.code);
-		printf("     error : %s\n", ret.error);
-		printf(" requestId : %s\n", ret.requestId);
-		//printf("  invalidUrls : %s\n", ret.invalidUrls);
-		//printf("  invalidDirs : %s\n", ret.invalidDirs);
-		printf("  quotaDay : %d\n", ret.quotaDay);
-		printf("surplusDay : %d\n", ret.surplusDay);
-		printf("-----------------------------------------\n");
-	}
+	//if (err.code == 200) {
+		printf("---------------------------------------------------\n");
+		printf("       code : %d\n", ret.code);
+		printf("  msg/error : %s\n", ret.error);
+		printf("  requestId : %s\n", ret.requestId);
+		printf("invalidUrls : %s\n", ret.invalidUrls);
+		printf("   quotaDay : %d\n", ret.quotaDay);
+		printf(" surplusDay : %d\n", ret.surplusDay);
+		printf("---------------------------------------------------\n");
+	//}
+
+	Qiniu_Free_CdnPrefetchRet(&ret);
 
 	Qiniu_Client_Cleanup(&cli);
 	//Qiniu_MacAuth_Cleanup();

--- a/demo/cdn_prefetch.c
+++ b/demo/cdn_prefetch.c
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
 	Qiniu_Error err;
 	Qiniu_Client cli;
 	Qiniu_Mac mac;
-    Qiniu_Cdn_PrefetchRet ret;
+	Qiniu_Cdn_PrefetchRet ret;
 
 	Qiniu_Global_Init(0);
 	Qiniu_Servend_Init(0);
@@ -17,11 +17,11 @@ int main(int argc, char * argv[])
 	mac.accessKey = argv[1];
 	mac.secretKey = argv[2];
 
-    char* urls[2] = {"http://a.com/1.html","http://b.com/2.html"};
+	char* urls[2] = { "http://a.com/1.html","http://b.com/2.html" };
 
 	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
 
-    err = Qiniu_Cdn_PrefetchUrls(&cli,&ret,urls,2);
+	err = Qiniu_Cdn_PrefetchUrls(&cli, &ret, urls, 2);
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 

--- a/demo/cdn_prefetch.c
+++ b/demo/cdn_prefetch.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../qiniu/http.h"
+#include "../qiniu/cdn.h"
+
+int main(int argc, char * argv[])
+{
+	Qiniu_Error err;
+	Qiniu_Client cli;
+	Qiniu_Mac mac;
+    Qiniu_Cdn_PrefetchRet ret;
+
+	Qiniu_Global_Init(0);
+	Qiniu_Servend_Init(0);
+	Qiniu_MacAuth_Init();
+
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+
+    char* urls[2] = {"http://a.com/1.html","http://b.com/2.html"};
+
+	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
+
+    err = Qiniu_Cdn_PrefetchUrls(&cli,&ret,urls,2);
+
+	printf("code:%d\n msg:%s\n", err.code, err.message);
+
+	if (err.code == 200) {
+		printf("-----------------------------------------\n");
+		printf("      code : %d\n", ret.code);
+		printf("     error : %s\n", ret.error);
+		printf(" requestId : %s\n", ret.requestId);
+		//printf("  invalidUrls : %s\n", ret.invalidUrls);
+		//printf("  invalidDirs : %s\n", ret.invalidDirs);
+		printf("  quotaDay : %d\n", ret.quotaDay);
+		printf("surplusDay : %d\n", ret.surplusDay);
+		printf("-----------------------------------------\n");
+	}
+
+	Qiniu_Client_Cleanup(&cli);
+	//Qiniu_MacAuth_Cleanup();
+	Qiniu_Servend_Cleanup();
+	Qiniu_Global_Cleanup();
+
+	return 0;
+} // main

--- a/demo/cdn_refresh.c
+++ b/demo/cdn_refresh.c
@@ -8,7 +8,7 @@ int main(int argc, char * argv[])
 	Qiniu_Error err;
 	Qiniu_Client cli;
 	Qiniu_Mac mac;
-    Qiniu_Cdn_RefreshRet ret;
+	Qiniu_Cdn_RefreshRet ret;
 
 	Qiniu_Global_Init(0);
 	Qiniu_Servend_Init(0);
@@ -17,11 +17,11 @@ int main(int argc, char * argv[])
 	mac.accessKey = argv[1];
 	mac.secretKey = argv[2];
 
-    char* urls[2] = {"http://a.com/1.html","http://b.com/2.html"};
+	char* urls[2] = { "http://a.com/1.html","http://b.com/2.html" };
 
 	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
 
-    err = Qiniu_Cdn_RefreshUrls(&cli,&ret,urls,2);
+	err = Qiniu_Cdn_RefreshUrls(&cli, &ret, urls, 2);
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 

--- a/demo/cdn_refresh.c
+++ b/demo/cdn_refresh.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../qiniu/http.h"
+#include "../qiniu/cdn.h"
+
+int main(int argc, char * argv[])
+{
+	Qiniu_Error err;
+	Qiniu_Client cli;
+	Qiniu_Mac mac;
+    Qiniu_Cdn_RefreshRet ret;
+
+	Qiniu_Global_Init(0);
+	Qiniu_Servend_Init(0);
+	Qiniu_MacAuth_Init();
+
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+
+    char* urls[2] = {"http://a.com/1.html","http://b.com/2.html"};
+
+	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
+
+    err = Qiniu_Cdn_RefreshUrls(&cli,&ret,urls,2);
+
+	printf("code:%d\n msg:%s\n", err.code, err.message);
+
+	if (err.code == 200) {
+		printf("-----------------------------------------\n");
+		printf("         code : %d\n", ret.code);
+		printf("        error : %s\n", ret.error);
+		printf("    requestId : %s\n", ret.requestId);
+		//printf("  invalidUrls : %s\n", ret.invalidUrls);
+		//printf("  invalidDirs : %s\n", ret.invalidDirs);
+		printf("  urlQuotaDay : %d\n", ret.urlQuotaDay);
+		printf("urlSurplusDay : %d\n", ret.urlSurplusDay);
+		printf("  dirQuotaDay : %d\n", ret.dirQuotaDay);
+		printf("dirSurplusDay : %d\n", ret.dirSurplusDay);
+		printf("-----------------------------------------\n");
+	}
+
+	Qiniu_Client_Cleanup(&cli);
+	//Qiniu_MacAuth_Cleanup();
+	Qiniu_Servend_Cleanup();
+	Qiniu_Global_Cleanup();
+
+	return 0;
+} // main

--- a/demo/cdn_refresh.c
+++ b/demo/cdn_refresh.c
@@ -21,23 +21,25 @@ int main(int argc, char * argv[])
 
 	Qiniu_Client_InitMacAuth(&cli, 1024, &mac);
 
-	err = Qiniu_Cdn_RefreshUrls(&cli, &ret, urls, 2);
+	err = Qiniu_Cdn_RefreshUrls(&cli, &ret, urls, 1);
 
 	printf("code:%d\n msg:%s\n", err.code, err.message);
 
-	if (err.code == 200) {
-		printf("-----------------------------------------\n");
+	//if (err.code == 200) {
+		printf("---------------------------------------------------\n");
 		printf("         code : %d\n", ret.code);
-		printf("        error : %s\n", ret.error);
+		printf("    msg/error : %s\n", ret.error);
 		printf("    requestId : %s\n", ret.requestId);
-		//printf("  invalidUrls : %s\n", ret.invalidUrls);
-		//printf("  invalidDirs : %s\n", ret.invalidDirs);
+		printf("  invalidUrls : %s\n", ret.invalidUrls);
+		printf("  invalidDirs : %s\n", ret.invalidDirs);
 		printf("  urlQuotaDay : %d\n", ret.urlQuotaDay);
 		printf("urlSurplusDay : %d\n", ret.urlSurplusDay);
 		printf("  dirQuotaDay : %d\n", ret.dirQuotaDay);
 		printf("dirSurplusDay : %d\n", ret.dirSurplusDay);
-		printf("-----------------------------------------\n");
-	}
+		printf("---------------------------------------------------\n");
+	//}
+
+	Qiniu_Free_CdnRefreshRet(&ret);
 
 	Qiniu_Client_Cleanup(&cli);
 	//Qiniu_MacAuth_Cleanup();

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -1,4 +1,4 @@
-/******************************************************************************* 
+/*******************************************************************************
  *  @file      demo.c 2013\10\11 10:55:14 $
  *  @author    Wang Xiaotao<wangxiaotao1980@gmail.com> (中文编码测试)
  ******************************************************************************/
@@ -10,39 +10,39 @@
 #include "base.h"
 
 #include <stdio.h>
-/******************************************************************************/
+ /******************************************************************************/
 
 
-/*debug 函数*/
+ /*debug 函数*/
 void debuginfo(Qiniu_Client* client, Qiniu_Error err)
 {
-    printf("\nerror code: %d, message: %s\n", err.code, err.message);
-    printf("response header:\n%s", Qiniu_Buffer_CStr(&client->respHeader));
-    printf("response body:\n%s", Qiniu_Buffer_CStr(&client->b));
-    printf("\n\n\n");
+	printf("\nerror code: %d, message: %s\n", err.code, err.message);
+	printf("response header:\n%s", Qiniu_Buffer_CStr(&client->respHeader));
+	printf("response body:\n%s", Qiniu_Buffer_CStr(&client->b));
+	printf("\n\n\n");
 }
 /*得到上传文件的token*/
 char* upLoadToken(const char* bucket, Qiniu_Mac* mac)
 {
-    Qiniu_RS_PutPolicy putPolicy;
-    Qiniu_Zero(putPolicy);
-    putPolicy.scope = bucket;
-    return Qiniu_RS_PutPolicy_Token(&putPolicy, mac);
+	Qiniu_RS_PutPolicy putPolicy;
+	Qiniu_Zero(putPolicy);
+	putPolicy.scope = bucket;
+	return Qiniu_RS_PutPolicy_Token(&putPolicy, mac);
 }
 /*得到下载文件的url的token*/
 char* downloadUrl(const char* domain, const char* key, Qiniu_Mac* mac)
 {
 
-    char* url = 0;
-    char* baseUrl = 0;
+	char* url = 0;
+	char* baseUrl = 0;
 
-    Qiniu_RS_GetPolicy getPolicy;
-    Qiniu_Zero(getPolicy);
+	Qiniu_RS_GetPolicy getPolicy;
+	Qiniu_Zero(getPolicy);
 
-    baseUrl = Qiniu_RS_MakeBaseUrl(domain, key);
-    url = Qiniu_RS_GetPolicy_MakeRequest(&getPolicy, baseUrl, mac);
-    Qiniu_Free(baseUrl);
-    return url;
+	baseUrl = Qiniu_RS_MakeBaseUrl(domain, key);
+	url = Qiniu_RS_GetPolicy_MakeRequest(&getPolicy, baseUrl, mac);
+	Qiniu_Free(baseUrl);
+	return url;
 }
 
 
@@ -50,243 +50,244 @@ char* downloadUrl(const char* domain, const char* key, Qiniu_Mac* mac)
 void demoGetFileStat(Qiniu_Client* pClient, const char* bucketName, const char* keyName)
 {
 
-    /* 假设Qiniu帐号存储下有 bucket名称为bucketName所指字符串， 此bucket下有keyName所指字符串的名称文件，
-     * 则此如下方法，查询keyName的文件信息
-     */
-    Qiniu_RS_StatRet statRet;
-    Qiniu_Error error = Qiniu_RS_Stat(pClient, &statRet, bucketName, keyName);
-    /* 判断http返回值*/
-    if (error.code != 200)
-    {   /*非200，不正确返回*/
-        printf("get file %s:%s stat error.\n", bucketName, keyName);
-        debuginfo(pClient, error);
-    }else
-    {   /*200, 正确返回了, 你可以通过statRet变量查询一些关于这个文件的信息*/
-         printf("get file %s:%s stat success.\n", bucketName, keyName);
-    }
+	/* 假设Qiniu帐号存储下有 bucket名称为bucketName所指字符串， 此bucket下有keyName所指字符串的名称文件，
+	 * 则此如下方法，查询keyName的文件信息
+	 */
+	Qiniu_RS_StatRet statRet;
+	Qiniu_Error error = Qiniu_RS_Stat(pClient, &statRet, bucketName, keyName);
+	/* 判断http返回值*/
+	if (error.code != 200)
+	{   /*非200，不正确返回*/
+		printf("get file %s:%s stat error.\n", bucketName, keyName);
+		debuginfo(pClient, error);
+	}
+	else
+	{   /*200, 正确返回了, 你可以通过statRet变量查询一些关于这个文件的信息*/
+		printf("get file %s:%s stat success.\n", bucketName, keyName);
+	}
 }
 
 void demoMoveFile(Qiniu_Client* pClient, const char* bucketName, const char* src, const char* dest)
 {
-    /* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有名称为src文件，
-     * 则此如下方法，改名子src 为 dest
-     */
-    Qiniu_Error error = Qiniu_RS_Move(pClient, bucketName, src , bucketName, dest);
-    if (error.code != 200)
-    {
-        printf("rename file from %s:%s to %s:%s error.\n", bucketName, src, bucketName, dest);
-        debuginfo(pClient, error);
-    }
-    else
-    {
-       printf("rename file from %s:%s to %s:%s success.\n", bucketName, src, bucketName, dest);
-    }
+	/* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有名称为src文件，
+	 * 则此如下方法，改名子src 为 dest
+	 */
+	Qiniu_Error error = Qiniu_RS_Move(pClient, bucketName, src, bucketName, dest);
+	if (error.code != 200)
+	{
+		printf("rename file from %s:%s to %s:%s error.\n", bucketName, src, bucketName, dest);
+		debuginfo(pClient, error);
+	}
+	else
+	{
+		printf("rename file from %s:%s to %s:%s success.\n", bucketName, src, bucketName, dest);
+	}
 
 
-    /* 以上改名的逆操作
-     */
-    error = Qiniu_RS_Move(pClient, bucketName, dest , bucketName, src);
-    if (error.code != 200)
-    {
-        printf("rename file from %s:%s to %s:%s error.\n", bucketName,dest, bucketName, src);
-        debuginfo(pClient, error);
-    }
-    else
-    {
-       printf("rename file from %s:%s to %s:%s success.\n", bucketName, dest, bucketName, src);
-    }
+	/* 以上改名的逆操作
+	 */
+	error = Qiniu_RS_Move(pClient, bucketName, dest, bucketName, src);
+	if (error.code != 200)
+	{
+		printf("rename file from %s:%s to %s:%s error.\n", bucketName, dest, bucketName, src);
+		debuginfo(pClient, error);
+	}
+	else
+	{
+		printf("rename file from %s:%s to %s:%s success.\n", bucketName, dest, bucketName, src);
+	}
 }
 
 void demoCopyFile(Qiniu_Client* pClient, const char* bucketName, const char* src, const char* dest)
 {
-    /* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有src文件，
-     * 则此如下方法，拷贝src 为 dest
-     */
-    Qiniu_Error error = Qiniu_RS_Copy(pClient, bucketName, src, bucketName, dest);
-    if (error.code != 200)
-    {
-        printf("copy file from %s:%s to %s:%s error.\n", bucketName, src, bucketName, dest);
-        debuginfo(pClient, error);
-    }
-    else
-    {
-        printf("copy file from %s:%s to %s:%s success.\n", bucketName, src, bucketName, dest);
-    }
+	/* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有src文件，
+	 * 则此如下方法，拷贝src 为 dest
+	 */
+	Qiniu_Error error = Qiniu_RS_Copy(pClient, bucketName, src, bucketName, dest);
+	if (error.code != 200)
+	{
+		printf("copy file from %s:%s to %s:%s error.\n", bucketName, src, bucketName, dest);
+		debuginfo(pClient, error);
+	}
+	else
+	{
+		printf("copy file from %s:%s to %s:%s success.\n", bucketName, src, bucketName, dest);
+	}
 }
 
 void demoDeleteFile(Qiniu_Client* pClient, const char* bucketName, const char* keyName)
 {
-    /* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有 keyName 文件，
-     * 则此如下方法, 删除 keyName
-     */
+	/* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有 keyName 文件，
+	 * 则此如下方法, 删除 keyName
+	 */
 
-    Qiniu_Error error = Qiniu_RS_Delete(pClient, bucketName, keyName);
-    if (error.code != 200)
-    {
-        printf("delete file %s:%s error.\n", bucketName, keyName);
-        debuginfo(pClient, error);
-    }
-    else
-    {
-        printf("delete file %s:%s success.\n", bucketName, keyName);
-    }
+	Qiniu_Error error = Qiniu_RS_Delete(pClient, bucketName, keyName);
+	if (error.code != 200)
+	{
+		printf("delete file %s:%s error.\n", bucketName, keyName);
+		debuginfo(pClient, error);
+	}
+	else
+	{
+		printf("delete file %s:%s success.\n", bucketName, keyName);
+	}
 }
 
 void demoBatchStatFiles(Qiniu_Client* pClient, const char* bucketName)
 {
-    /*  假设Qiniu帐号存储下有 bucket名称为bucketName，此bucket 下有批量文件
-     *  此demo function演示如何批量得到七牛云存储文件信息
-     */
-    Qiniu_RS_EntryPath entryPath[] = {
-                                        {bucketName, "1.txt"},
-                                        {bucketName, "2.txt"},
-                                        {bucketName, "3.txt"},
-                                        {bucketName, "4.txt"},
-                                        {bucketName, "5.txt"},
-                                       };
-    int len = sizeof(entryPath)/sizeof(Qiniu_RS_EntryPath);
-    Qiniu_RS_BatchStatRet* rets = (Qiniu_RS_BatchStatRet*)calloc(len, sizeof(Qiniu_RS_BatchStatRet));
-    Qiniu_Error error = Qiniu_RS_BatchStat(pClient, rets, entryPath, len);
-    if (200 != error.code)
-    {
-        printf("get files stat error.\n");
-        debuginfo(pClient, error);
-    }
-    else
-    {
-        printf("get files stat success.\n");
-    }
-    free(rets);
+	/*  假设Qiniu帐号存储下有 bucket名称为bucketName，此bucket 下有批量文件
+	 *  此demo function演示如何批量得到七牛云存储文件信息
+	 */
+	Qiniu_RS_EntryPath entryPath[] = {
+										{bucketName, "1.txt"},
+										{bucketName, "2.txt"},
+										{bucketName, "3.txt"},
+										{bucketName, "4.txt"},
+										{bucketName, "5.txt"},
+	};
+	int len = sizeof(entryPath) / sizeof(Qiniu_RS_EntryPath);
+	Qiniu_RS_BatchStatRet* rets = (Qiniu_RS_BatchStatRet*)calloc(len, sizeof(Qiniu_RS_BatchStatRet));
+	Qiniu_Error error = Qiniu_RS_BatchStat(pClient, rets, entryPath, len);
+	if (200 != error.code)
+	{
+		printf("get files stat error.\n");
+		debuginfo(pClient, error);
+	}
+	else
+	{
+		printf("get files stat success.\n");
+	}
+	free(rets);
 }
 
 void demoBatchCopyFiles(Qiniu_Client* pClient, const char* bucketName)
 {
-    Qiniu_RS_EntryPathPair entryPathpair1[] ={{{bucketName, "1.txt"}, {bucketName, "1_copy.txt"}},
-                                              {{bucketName, "2.txt"}, {bucketName, "2_copy.txt"}},
-                                              {{bucketName, "3.txt"}, {bucketName, "3_copy.txt"}},
-                                              {{bucketName, "4.txt"}, {bucketName, "4_copy.txt"}},
-                                              {{bucketName, "5.txt"}, {bucketName, "5_copy.txt"}},
-                                             };
-    int len = sizeof(entryPathpair1)/sizeof(Qiniu_RS_EntryPathPair);
-    Qiniu_RS_BatchItemRet* itemRets = (Qiniu_RS_BatchItemRet*)calloc(len, sizeof(Qiniu_RS_BatchItemRet));
-    Qiniu_Error error = Qiniu_RS_BatchCopy(pClient, itemRets, entryPathpair1, len);
-    if (200 != error.code)
-    {
-        printf("copy files error.\n");
-        debuginfo(pClient, error);
-    }
-    else
-    {
-        printf("copy files success.\n");
-    }
-    Qiniu_Free(itemRets);
+	Qiniu_RS_EntryPathPair entryPathpair1[] = { {{bucketName, "1.txt"}, {bucketName, "1_copy.txt"}},
+											  {{bucketName, "2.txt"}, {bucketName, "2_copy.txt"}},
+											  {{bucketName, "3.txt"}, {bucketName, "3_copy.txt"}},
+											  {{bucketName, "4.txt"}, {bucketName, "4_copy.txt"}},
+											  {{bucketName, "5.txt"}, {bucketName, "5_copy.txt"}},
+	};
+	int len = sizeof(entryPathpair1) / sizeof(Qiniu_RS_EntryPathPair);
+	Qiniu_RS_BatchItemRet* itemRets = (Qiniu_RS_BatchItemRet*)calloc(len, sizeof(Qiniu_RS_BatchItemRet));
+	Qiniu_Error error = Qiniu_RS_BatchCopy(pClient, itemRets, entryPathpair1, len);
+	if (200 != error.code)
+	{
+		printf("copy files error.\n");
+		debuginfo(pClient, error);
+	}
+	else
+	{
+		printf("copy files success.\n");
+	}
+	Qiniu_Free(itemRets);
 }
 
 void demoBatchDeleteFiles(Qiniu_Client* pClient, const char* bucketName)
 {
-    Qiniu_RS_EntryPath entryPath1[] = {
-                                        {bucketName, "1_copy.txt"},
-                                        {bucketName, "2_copy.txt"},
-                                        {bucketName, "3_copy.txt"},
-                                        {bucketName, "4_copy.txt"},
-                                        {bucketName, "5_copy.txt"},
-                                      };
-    int len = sizeof(entryPath1)/sizeof(Qiniu_RS_EntryPath);
-     Qiniu_RS_BatchItemRet* itemRets = (Qiniu_RS_BatchItemRet*)calloc(len, sizeof(Qiniu_RS_BatchItemRet));
-    Qiniu_Error error = Qiniu_RS_BatchDelete(pClient, itemRets, entryPath1, len);
-    if (200 != error.code)
-    {
-        printf("delete files error.\n");
-        debuginfo(pClient, error);
-    }
-    else
-    {
-        printf("delete files success.\n");
-    }
-    Qiniu_Free(itemRets);
+	Qiniu_RS_EntryPath entryPath1[] = {
+										{bucketName, "1_copy.txt"},
+										{bucketName, "2_copy.txt"},
+										{bucketName, "3_copy.txt"},
+										{bucketName, "4_copy.txt"},
+										{bucketName, "5_copy.txt"},
+	};
+	int len = sizeof(entryPath1) / sizeof(Qiniu_RS_EntryPath);
+	Qiniu_RS_BatchItemRet* itemRets = (Qiniu_RS_BatchItemRet*)calloc(len, sizeof(Qiniu_RS_BatchItemRet));
+	Qiniu_Error error = Qiniu_RS_BatchDelete(pClient, itemRets, entryPath1, len);
+	if (200 != error.code)
+	{
+		printf("delete files error.\n");
+		debuginfo(pClient, error);
+	}
+	else
+	{
+		printf("delete files success.\n");
+	}
+	Qiniu_Free(itemRets);
 }
 
 
 void demoUploadFile(Qiniu_Client* pClient, const char* bucketName, Qiniu_Mac* mac)
 {
-    const char* uploadName = "testUpload1.hpp";
-    /*得到uploadKey*/
-    const char* uploadtoken = upLoadToken(bucketName, mac);
+	const char* uploadName = "testUpload1.hpp";
+	/*得到uploadKey*/
+	const char* uploadtoken = upLoadToken(bucketName, mac);
 
-    const char* pLocalFilePath = "C:\\3rdLib\\operators.hpp";
-    
-    Qiniu_Io_PutRet putRet;
-    Qiniu_Error error = Qiniu_Io_PutFile(pClient, &putRet, uploadtoken, uploadName, pLocalFilePath, NULL);
-    if (error.code != 200) 
-    {
-        printf("Upload File %s To %s:%s error.\n", pLocalFilePath, bucketName,  uploadName);
-        debuginfo(pClient, error);
-    }
-    else
-    {
-        printf("Upload File %s To %s:%s success.\n", pLocalFilePath, bucketName,  uploadName);
-    }
+	const char* pLocalFilePath = "C:\\3rdLib\\operators.hpp";
 
-    Qiniu_Free(uploadtoken);
+	Qiniu_Io_PutRet putRet;
+	Qiniu_Error error = Qiniu_Io_PutFile(pClient, &putRet, uploadtoken, uploadName, pLocalFilePath, NULL);
+	if (error.code != 200)
+	{
+		printf("Upload File %s To %s:%s error.\n", pLocalFilePath, bucketName, uploadName);
+		debuginfo(pClient, error);
+	}
+	else
+	{
+		printf("Upload File %s To %s:%s success.\n", pLocalFilePath, bucketName, uploadName);
+	}
+
+	Qiniu_Free(uploadtoken);
 }
 
 
 void demoGetDownloadURL(const char* bucketName, Qiniu_Mac* mac)
 {
-    char* domain = Qiniu_String_Concat2(bucketName, ".u.qiniudn.com");
-    const char* downloadName = "testUpload1.hpp";
-    char* pUrl = downloadUrl(domain, downloadName, mac);
+	char* domain = Qiniu_String_Concat2(bucketName, ".u.qiniudn.com");
+	const char* downloadName = "testUpload1.hpp";
+	char* pUrl = downloadUrl(domain, downloadName, mac);
 
-    if (0 == pUrl)
-    {
-        printf("get URL %s:%s error.\n", bucketName, downloadName);
-    }
-    else 
-    {
-        printf("get URL %s:%s is %s.\n", bucketName, downloadName, pUrl);
-    }
+	if (0 == pUrl)
+	{
+		printf("get URL %s:%s error.\n", bucketName, downloadName);
+	}
+	else
+	{
+		printf("get URL %s:%s is %s.\n", bucketName, downloadName, pUrl);
+	}
 
-    Qiniu_Free(pUrl);
-    Qiniu_Free(domain);
+	Qiniu_Free(pUrl);
+	Qiniu_Free(domain);
 }
 
 int main(int argc, char** argv)
 {
 
-    Qiniu_Client client;
-    Qiniu_Mac    mac;
-    char* bucketName = "qiniu-demo-test";
+	Qiniu_Client client;
+	Qiniu_Mac    mac;
+	char* bucketName = "qiniu-demo-test";
 
-    mac.accessKey = argv[1];
-    mac.secretKey = argv[2];
-    // 初始化
-    Qiniu_Servend_Init(-1);
-    Qiniu_Client_InitMacAuth(&client, 1024, &mac);
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+	// 初始化
+	Qiniu_Servend_Init(-1);
+	Qiniu_Client_InitMacAuth(&client, 1024, &mac);
 
-    /* 此方法展示如何得到七牛云存储的一个文件的信息*/
-    //demoGetFileStat(&client, bucketName, "a.txt");
-    /* 此方法展示如何更改七牛云存储的一个文件的名称*/
-    //demoMoveFile(&client, bucketName, "a.txt", "b.txt");
-    /* 此方法展示如何复制七牛云存储的一个文件*/
-    //demoCopyFile(&client, bucketName, "a.txt", "a_back.txt");
-    /* 此方法展示如何删除七牛云存储的一个文件*/
-    //demoDeleteFile(&client, bucketName, "a_back.txt");
-    /* 此方法展示如何批量的得到七牛云存储文件的信息*/
-    //demoBatchStatFiles(&client, bucketName);
-    /* 此方法展示如何批量复制七牛云存储文件*/
-    //demoBatchCopyFiles(&client, bucketName);
-    /* 此方法展示如何批量删除七牛云存储文件*/
-    //demoBatchDeleteFiles(&client, bucketName);
+	/* 此方法展示如何得到七牛云存储的一个文件的信息*/
+	//demoGetFileStat(&client, bucketName, "a.txt");
+	/* 此方法展示如何更改七牛云存储的一个文件的名称*/
+	//demoMoveFile(&client, bucketName, "a.txt", "b.txt");
+	/* 此方法展示如何复制七牛云存储的一个文件*/
+	//demoCopyFile(&client, bucketName, "a.txt", "a_back.txt");
+	/* 此方法展示如何删除七牛云存储的一个文件*/
+	//demoDeleteFile(&client, bucketName, "a_back.txt");
+	/* 此方法展示如何批量的得到七牛云存储文件的信息*/
+	//demoBatchStatFiles(&client, bucketName);
+	/* 此方法展示如何批量复制七牛云存储文件*/
+	//demoBatchCopyFiles(&client, bucketName);
+	/* 此方法展示如何批量删除七牛云存储文件*/
+	//demoBatchDeleteFiles(&client, bucketName);
 
-    /* 此方法展示如何上传一个本地文件到服务器*/
-    //demoUploadFile(&client, bucketName, &mac);
-    /*此方法展示如何得到一个服务器上的文件的，下载url*/
-    //demoGetDownloadURL(bucketName, &mac);
+	/* 此方法展示如何上传一个本地文件到服务器*/
+	//demoUploadFile(&client, bucketName, &mac);
+	/*此方法展示如何得到一个服务器上的文件的，下载url*/
+	//demoGetDownloadURL(bucketName, &mac);
 
-    // 反初始化
-    Qiniu_Client_Cleanup(&client);
-    Qiniu_Servend_Cleanup();
-    return 0;
+	// 反初始化
+	Qiniu_Client_Cleanup(&client);
+	Qiniu_Servend_Cleanup();
+	return 0;
 }
 
 // 

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/******************************************************************************* 
  *  @file      demo.c 2013\10\11 10:55:14 $
  *  @author    Wang Xiaotao<wangxiaotao1980@gmail.com> (中文编码测试)
  ******************************************************************************/
@@ -10,39 +10,39 @@
 #include "base.h"
 
 #include <stdio.h>
- /******************************************************************************/
+/******************************************************************************/
 
 
- /*debug 函数*/
+/*debug 函数*/
 void debuginfo(Qiniu_Client* client, Qiniu_Error err)
 {
-	printf("\nerror code: %d, message: %s\n", err.code, err.message);
-	printf("response header:\n%s", Qiniu_Buffer_CStr(&client->respHeader));
-	printf("response body:\n%s", Qiniu_Buffer_CStr(&client->b));
-	printf("\n\n\n");
+    printf("\nerror code: %d, message: %s\n", err.code, err.message);
+    printf("response header:\n%s", Qiniu_Buffer_CStr(&client->respHeader));
+    printf("response body:\n%s", Qiniu_Buffer_CStr(&client->b));
+    printf("\n\n\n");
 }
 /*得到上传文件的token*/
 char* upLoadToken(const char* bucket, Qiniu_Mac* mac)
 {
-	Qiniu_RS_PutPolicy putPolicy;
-	Qiniu_Zero(putPolicy);
-	putPolicy.scope = bucket;
-	return Qiniu_RS_PutPolicy_Token(&putPolicy, mac);
+    Qiniu_RS_PutPolicy putPolicy;
+    Qiniu_Zero(putPolicy);
+    putPolicy.scope = bucket;
+    return Qiniu_RS_PutPolicy_Token(&putPolicy, mac);
 }
 /*得到下载文件的url的token*/
 char* downloadUrl(const char* domain, const char* key, Qiniu_Mac* mac)
 {
 
-	char* url = 0;
-	char* baseUrl = 0;
+    char* url = 0;
+    char* baseUrl = 0;
 
-	Qiniu_RS_GetPolicy getPolicy;
-	Qiniu_Zero(getPolicy);
+    Qiniu_RS_GetPolicy getPolicy;
+    Qiniu_Zero(getPolicy);
 
-	baseUrl = Qiniu_RS_MakeBaseUrl(domain, key);
-	url = Qiniu_RS_GetPolicy_MakeRequest(&getPolicy, baseUrl, mac);
-	Qiniu_Free(baseUrl);
-	return url;
+    baseUrl = Qiniu_RS_MakeBaseUrl(domain, key);
+    url = Qiniu_RS_GetPolicy_MakeRequest(&getPolicy, baseUrl, mac);
+    Qiniu_Free(baseUrl);
+    return url;
 }
 
 
@@ -50,244 +50,243 @@ char* downloadUrl(const char* domain, const char* key, Qiniu_Mac* mac)
 void demoGetFileStat(Qiniu_Client* pClient, const char* bucketName, const char* keyName)
 {
 
-	/* 假设Qiniu帐号存储下有 bucket名称为bucketName所指字符串， 此bucket下有keyName所指字符串的名称文件，
-	 * 则此如下方法，查询keyName的文件信息
-	 */
-	Qiniu_RS_StatRet statRet;
-	Qiniu_Error error = Qiniu_RS_Stat(pClient, &statRet, bucketName, keyName);
-	/* 判断http返回值*/
-	if (error.code != 200)
-	{   /*非200，不正确返回*/
-		printf("get file %s:%s stat error.\n", bucketName, keyName);
-		debuginfo(pClient, error);
-	}
-	else
-	{   /*200, 正确返回了, 你可以通过statRet变量查询一些关于这个文件的信息*/
-		printf("get file %s:%s stat success.\n", bucketName, keyName);
-	}
+    /* 假设Qiniu帐号存储下有 bucket名称为bucketName所指字符串， 此bucket下有keyName所指字符串的名称文件，
+     * 则此如下方法，查询keyName的文件信息
+     */
+    Qiniu_RS_StatRet statRet;
+    Qiniu_Error error = Qiniu_RS_Stat(pClient, &statRet, bucketName, keyName);
+    /* 判断http返回值*/
+    if (error.code != 200)
+    {   /*非200，不正确返回*/
+        printf("get file %s:%s stat error.\n", bucketName, keyName);
+        debuginfo(pClient, error);
+    }else
+    {   /*200, 正确返回了, 你可以通过statRet变量查询一些关于这个文件的信息*/
+         printf("get file %s:%s stat success.\n", bucketName, keyName);
+    }
 }
 
 void demoMoveFile(Qiniu_Client* pClient, const char* bucketName, const char* src, const char* dest)
 {
-	/* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有名称为src文件，
-	 * 则此如下方法，改名子src 为 dest
-	 */
-	Qiniu_Error error = Qiniu_RS_Move(pClient, bucketName, src, bucketName, dest);
-	if (error.code != 200)
-	{
-		printf("rename file from %s:%s to %s:%s error.\n", bucketName, src, bucketName, dest);
-		debuginfo(pClient, error);
-	}
-	else
-	{
-		printf("rename file from %s:%s to %s:%s success.\n", bucketName, src, bucketName, dest);
-	}
+    /* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有名称为src文件，
+     * 则此如下方法，改名子src 为 dest
+     */
+    Qiniu_Error error = Qiniu_RS_Move(pClient, bucketName, src , bucketName, dest);
+    if (error.code != 200)
+    {
+        printf("rename file from %s:%s to %s:%s error.\n", bucketName, src, bucketName, dest);
+        debuginfo(pClient, error);
+    }
+    else
+    {
+       printf("rename file from %s:%s to %s:%s success.\n", bucketName, src, bucketName, dest);
+    }
 
 
-	/* 以上改名的逆操作
-	 */
-	error = Qiniu_RS_Move(pClient, bucketName, dest, bucketName, src);
-	if (error.code != 200)
-	{
-		printf("rename file from %s:%s to %s:%s error.\n", bucketName, dest, bucketName, src);
-		debuginfo(pClient, error);
-	}
-	else
-	{
-		printf("rename file from %s:%s to %s:%s success.\n", bucketName, dest, bucketName, src);
-	}
+    /* 以上改名的逆操作
+     */
+    error = Qiniu_RS_Move(pClient, bucketName, dest , bucketName, src);
+    if (error.code != 200)
+    {
+        printf("rename file from %s:%s to %s:%s error.\n", bucketName,dest, bucketName, src);
+        debuginfo(pClient, error);
+    }
+    else
+    {
+       printf("rename file from %s:%s to %s:%s success.\n", bucketName, dest, bucketName, src);
+    }
 }
 
 void demoCopyFile(Qiniu_Client* pClient, const char* bucketName, const char* src, const char* dest)
 {
-	/* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有src文件，
-	 * 则此如下方法，拷贝src 为 dest
-	 */
-	Qiniu_Error error = Qiniu_RS_Copy(pClient, bucketName, src, bucketName, dest);
-	if (error.code != 200)
-	{
-		printf("copy file from %s:%s to %s:%s error.\n", bucketName, src, bucketName, dest);
-		debuginfo(pClient, error);
-	}
-	else
-	{
-		printf("copy file from %s:%s to %s:%s success.\n", bucketName, src, bucketName, dest);
-	}
+    /* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有src文件，
+     * 则此如下方法，拷贝src 为 dest
+     */
+    Qiniu_Error error = Qiniu_RS_Copy(pClient, bucketName, src, bucketName, dest);
+    if (error.code != 200)
+    {
+        printf("copy file from %s:%s to %s:%s error.\n", bucketName, src, bucketName, dest);
+        debuginfo(pClient, error);
+    }
+    else
+    {
+        printf("copy file from %s:%s to %s:%s success.\n", bucketName, src, bucketName, dest);
+    }
 }
 
 void demoDeleteFile(Qiniu_Client* pClient, const char* bucketName, const char* keyName)
 {
-	/* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有 keyName 文件，
-	 * 则此如下方法, 删除 keyName
-	 */
+    /* 假设Qiniu帐号存储下有 bucket名称为bucketName， 此bucket下有 keyName 文件，
+     * 则此如下方法, 删除 keyName
+     */
 
-	Qiniu_Error error = Qiniu_RS_Delete(pClient, bucketName, keyName);
-	if (error.code != 200)
-	{
-		printf("delete file %s:%s error.\n", bucketName, keyName);
-		debuginfo(pClient, error);
-	}
-	else
-	{
-		printf("delete file %s:%s success.\n", bucketName, keyName);
-	}
+    Qiniu_Error error = Qiniu_RS_Delete(pClient, bucketName, keyName);
+    if (error.code != 200)
+    {
+        printf("delete file %s:%s error.\n", bucketName, keyName);
+        debuginfo(pClient, error);
+    }
+    else
+    {
+        printf("delete file %s:%s success.\n", bucketName, keyName);
+    }
 }
 
 void demoBatchStatFiles(Qiniu_Client* pClient, const char* bucketName)
 {
-	/*  假设Qiniu帐号存储下有 bucket名称为bucketName，此bucket 下有批量文件
-	 *  此demo function演示如何批量得到七牛云存储文件信息
-	 */
-	Qiniu_RS_EntryPath entryPath[] = {
-										{bucketName, "1.txt"},
-										{bucketName, "2.txt"},
-										{bucketName, "3.txt"},
-										{bucketName, "4.txt"},
-										{bucketName, "5.txt"},
-	};
-	int len = sizeof(entryPath) / sizeof(Qiniu_RS_EntryPath);
-	Qiniu_RS_BatchStatRet* rets = (Qiniu_RS_BatchStatRet*)calloc(len, sizeof(Qiniu_RS_BatchStatRet));
-	Qiniu_Error error = Qiniu_RS_BatchStat(pClient, rets, entryPath, len);
-	if (200 != error.code)
-	{
-		printf("get files stat error.\n");
-		debuginfo(pClient, error);
-	}
-	else
-	{
-		printf("get files stat success.\n");
-	}
-	free(rets);
+    /*  假设Qiniu帐号存储下有 bucket名称为bucketName，此bucket 下有批量文件
+     *  此demo function演示如何批量得到七牛云存储文件信息
+     */
+    Qiniu_RS_EntryPath entryPath[] = {
+                                        {bucketName, "1.txt"},
+                                        {bucketName, "2.txt"},
+                                        {bucketName, "3.txt"},
+                                        {bucketName, "4.txt"},
+                                        {bucketName, "5.txt"},
+                                       };
+    int len = sizeof(entryPath)/sizeof(Qiniu_RS_EntryPath);
+    Qiniu_RS_BatchStatRet* rets = (Qiniu_RS_BatchStatRet*)calloc(len, sizeof(Qiniu_RS_BatchStatRet));
+    Qiniu_Error error = Qiniu_RS_BatchStat(pClient, rets, entryPath, len);
+    if (200 != error.code)
+    {
+        printf("get files stat error.\n");
+        debuginfo(pClient, error);
+    }
+    else
+    {
+        printf("get files stat success.\n");
+    }
+    free(rets);
 }
 
 void demoBatchCopyFiles(Qiniu_Client* pClient, const char* bucketName)
 {
-	Qiniu_RS_EntryPathPair entryPathpair1[] = { {{bucketName, "1.txt"}, {bucketName, "1_copy.txt"}},
-											  {{bucketName, "2.txt"}, {bucketName, "2_copy.txt"}},
-											  {{bucketName, "3.txt"}, {bucketName, "3_copy.txt"}},
-											  {{bucketName, "4.txt"}, {bucketName, "4_copy.txt"}},
-											  {{bucketName, "5.txt"}, {bucketName, "5_copy.txt"}},
-	};
-	int len = sizeof(entryPathpair1) / sizeof(Qiniu_RS_EntryPathPair);
-	Qiniu_RS_BatchItemRet* itemRets = (Qiniu_RS_BatchItemRet*)calloc(len, sizeof(Qiniu_RS_BatchItemRet));
-	Qiniu_Error error = Qiniu_RS_BatchCopy(pClient, itemRets, entryPathpair1, len);
-	if (200 != error.code)
-	{
-		printf("copy files error.\n");
-		debuginfo(pClient, error);
-	}
-	else
-	{
-		printf("copy files success.\n");
-	}
-	Qiniu_Free(itemRets);
+    Qiniu_RS_EntryPathPair entryPathpair1[] ={{{bucketName, "1.txt"}, {bucketName, "1_copy.txt"}},
+                                              {{bucketName, "2.txt"}, {bucketName, "2_copy.txt"}},
+                                              {{bucketName, "3.txt"}, {bucketName, "3_copy.txt"}},
+                                              {{bucketName, "4.txt"}, {bucketName, "4_copy.txt"}},
+                                              {{bucketName, "5.txt"}, {bucketName, "5_copy.txt"}},
+                                             };
+    int len = sizeof(entryPathpair1)/sizeof(Qiniu_RS_EntryPathPair);
+    Qiniu_RS_BatchItemRet* itemRets = (Qiniu_RS_BatchItemRet*)calloc(len, sizeof(Qiniu_RS_BatchItemRet));
+    Qiniu_Error error = Qiniu_RS_BatchCopy(pClient, itemRets, entryPathpair1, len);
+    if (200 != error.code)
+    {
+        printf("copy files error.\n");
+        debuginfo(pClient, error);
+    }
+    else
+    {
+        printf("copy files success.\n");
+    }
+    Qiniu_Free(itemRets);
 }
 
 void demoBatchDeleteFiles(Qiniu_Client* pClient, const char* bucketName)
 {
-	Qiniu_RS_EntryPath entryPath1[] = {
-										{bucketName, "1_copy.txt"},
-										{bucketName, "2_copy.txt"},
-										{bucketName, "3_copy.txt"},
-										{bucketName, "4_copy.txt"},
-										{bucketName, "5_copy.txt"},
-	};
-	int len = sizeof(entryPath1) / sizeof(Qiniu_RS_EntryPath);
-	Qiniu_RS_BatchItemRet* itemRets = (Qiniu_RS_BatchItemRet*)calloc(len, sizeof(Qiniu_RS_BatchItemRet));
-	Qiniu_Error error = Qiniu_RS_BatchDelete(pClient, itemRets, entryPath1, len);
-	if (200 != error.code)
-	{
-		printf("delete files error.\n");
-		debuginfo(pClient, error);
-	}
-	else
-	{
-		printf("delete files success.\n");
-	}
-	Qiniu_Free(itemRets);
+    Qiniu_RS_EntryPath entryPath1[] = {
+                                        {bucketName, "1_copy.txt"},
+                                        {bucketName, "2_copy.txt"},
+                                        {bucketName, "3_copy.txt"},
+                                        {bucketName, "4_copy.txt"},
+                                        {bucketName, "5_copy.txt"},
+                                      };
+    int len = sizeof(entryPath1)/sizeof(Qiniu_RS_EntryPath);
+     Qiniu_RS_BatchItemRet* itemRets = (Qiniu_RS_BatchItemRet*)calloc(len, sizeof(Qiniu_RS_BatchItemRet));
+    Qiniu_Error error = Qiniu_RS_BatchDelete(pClient, itemRets, entryPath1, len);
+    if (200 != error.code)
+    {
+        printf("delete files error.\n");
+        debuginfo(pClient, error);
+    }
+    else
+    {
+        printf("delete files success.\n");
+    }
+    Qiniu_Free(itemRets);
 }
 
 
 void demoUploadFile(Qiniu_Client* pClient, const char* bucketName, Qiniu_Mac* mac)
 {
-	const char* uploadName = "testUpload1.hpp";
-	/*得到uploadKey*/
-	const char* uploadtoken = upLoadToken(bucketName, mac);
+    const char* uploadName = "testUpload1.hpp";
+    /*得到uploadKey*/
+    const char* uploadtoken = upLoadToken(bucketName, mac);
 
-	const char* pLocalFilePath = "C:\\3rdLib\\operators.hpp";
+    const char* pLocalFilePath = "C:\\3rdLib\\operators.hpp";
+    
+    Qiniu_Io_PutRet putRet;
+    Qiniu_Error error = Qiniu_Io_PutFile(pClient, &putRet, uploadtoken, uploadName, pLocalFilePath, NULL);
+    if (error.code != 200) 
+    {
+        printf("Upload File %s To %s:%s error.\n", pLocalFilePath, bucketName,  uploadName);
+        debuginfo(pClient, error);
+    }
+    else
+    {
+        printf("Upload File %s To %s:%s success.\n", pLocalFilePath, bucketName,  uploadName);
+    }
 
-	Qiniu_Io_PutRet putRet;
-	Qiniu_Error error = Qiniu_Io_PutFile(pClient, &putRet, uploadtoken, uploadName, pLocalFilePath, NULL);
-	if (error.code != 200)
-	{
-		printf("Upload File %s To %s:%s error.\n", pLocalFilePath, bucketName, uploadName);
-		debuginfo(pClient, error);
-	}
-	else
-	{
-		printf("Upload File %s To %s:%s success.\n", pLocalFilePath, bucketName, uploadName);
-	}
-
-	Qiniu_Free(uploadtoken);
+    Qiniu_Free(uploadtoken);
 }
 
 
 void demoGetDownloadURL(const char* bucketName, Qiniu_Mac* mac)
 {
-	char* domain = Qiniu_String_Concat2(bucketName, ".u.qiniudn.com");
-	const char* downloadName = "testUpload1.hpp";
-	char* pUrl = downloadUrl(domain, downloadName, mac);
+    char* domain = Qiniu_String_Concat2(bucketName, ".u.qiniudn.com");
+    const char* downloadName = "testUpload1.hpp";
+    char* pUrl = downloadUrl(domain, downloadName, mac);
 
-	if (0 == pUrl)
-	{
-		printf("get URL %s:%s error.\n", bucketName, downloadName);
-	}
-	else
-	{
-		printf("get URL %s:%s is %s.\n", bucketName, downloadName, pUrl);
-	}
+    if (0 == pUrl)
+    {
+        printf("get URL %s:%s error.\n", bucketName, downloadName);
+    }
+    else 
+    {
+        printf("get URL %s:%s is %s.\n", bucketName, downloadName, pUrl);
+    }
 
-	Qiniu_Free(pUrl);
-	Qiniu_Free(domain);
+    Qiniu_Free(pUrl);
+    Qiniu_Free(domain);
 }
 
 int main(int argc, char** argv)
 {
 
-	Qiniu_Client client;
-	Qiniu_Mac    mac;
-	char* bucketName = "qiniu-demo-test";
+    Qiniu_Client client;
+    Qiniu_Mac    mac;
+    char* bucketName = "qiniu-demo-test";
 
-	mac.accessKey = argv[1];
-	mac.secretKey = argv[2];
-	// 初始化
-	Qiniu_Servend_Init(-1);
-	Qiniu_Client_InitMacAuth(&client, 1024, &mac);
+    mac.accessKey = argv[1];
+    mac.secretKey = argv[2];
+    // 初始化
+    Qiniu_Servend_Init(-1);
+    Qiniu_Client_InitMacAuth(&client, 1024, &mac);
 
-	/* 此方法展示如何得到七牛云存储的一个文件的信息*/
-	//demoGetFileStat(&client, bucketName, "a.txt");
-	/* 此方法展示如何更改七牛云存储的一个文件的名称*/
-	//demoMoveFile(&client, bucketName, "a.txt", "b.txt");
-	/* 此方法展示如何复制七牛云存储的一个文件*/
-	//demoCopyFile(&client, bucketName, "a.txt", "a_back.txt");
-	/* 此方法展示如何删除七牛云存储的一个文件*/
-	//demoDeleteFile(&client, bucketName, "a_back.txt");
-	/* 此方法展示如何批量的得到七牛云存储文件的信息*/
-	//demoBatchStatFiles(&client, bucketName);
-	/* 此方法展示如何批量复制七牛云存储文件*/
-	//demoBatchCopyFiles(&client, bucketName);
-	/* 此方法展示如何批量删除七牛云存储文件*/
-	//demoBatchDeleteFiles(&client, bucketName);
+    /* 此方法展示如何得到七牛云存储的一个文件的信息*/
+    //demoGetFileStat(&client, bucketName, "a.txt");
+    /* 此方法展示如何更改七牛云存储的一个文件的名称*/
+    //demoMoveFile(&client, bucketName, "a.txt", "b.txt");
+    /* 此方法展示如何复制七牛云存储的一个文件*/
+    //demoCopyFile(&client, bucketName, "a.txt", "a_back.txt");
+    /* 此方法展示如何删除七牛云存储的一个文件*/
+    //demoDeleteFile(&client, bucketName, "a_back.txt");
+    /* 此方法展示如何批量的得到七牛云存储文件的信息*/
+    //demoBatchStatFiles(&client, bucketName);
+    /* 此方法展示如何批量复制七牛云存储文件*/
+    //demoBatchCopyFiles(&client, bucketName);
+    /* 此方法展示如何批量删除七牛云存储文件*/
+    //demoBatchDeleteFiles(&client, bucketName);
 
-	/* 此方法展示如何上传一个本地文件到服务器*/
-	//demoUploadFile(&client, bucketName, &mac);
-	/*此方法展示如何得到一个服务器上的文件的，下载url*/
-	//demoGetDownloadURL(bucketName, &mac);
+    /* 此方法展示如何上传一个本地文件到服务器*/
+    //demoUploadFile(&client, bucketName, &mac);
+    /*此方法展示如何得到一个服务器上的文件的，下载url*/
+    //demoGetDownloadURL(bucketName, &mac);
 
-	// 反初始化
-	Qiniu_Client_Cleanup(&client);
-	Qiniu_Servend_Cleanup();
-	return 0;
+    // 反初始化
+    Qiniu_Client_Cleanup(&client);
+    Qiniu_Servend_Cleanup();
+    return 0;
 }
 
 // 

--- a/demo/demo.c
+++ b/demo/demo.c
@@ -250,38 +250,38 @@ void demoGetDownloadURL(const char* bucketName, Qiniu_Mac* mac)
     Qiniu_Free(domain);
 }
 
-int main()
+int main(int argc, char** argv)
 {
 
     Qiniu_Client client;
     Qiniu_Mac    mac;
     char* bucketName = "qiniu-demo-test";
 
-    mac.accessKey ="og9UTrj8I83ndelDQrzlpjXS8HwtiQVMV2S_v7D1";
-    mac.secretKey = "oGUsG0nvsCcltrlkci08qY48DaM-uC7MQjsWRPe0";
+    mac.accessKey = argv[1];
+    mac.secretKey = argv[2];
     // 初始化
     Qiniu_Servend_Init(-1);
     Qiniu_Client_InitMacAuth(&client, 1024, &mac);
 
     /* 此方法展示如何得到七牛云存储的一个文件的信息*/
-    demoGetFileStat(&client, bucketName, "a.txt");
+    //demoGetFileStat(&client, bucketName, "a.txt");
     /* 此方法展示如何更改七牛云存储的一个文件的名称*/
-    demoMoveFile(&client, bucketName, "a.txt", "b.txt");
+    //demoMoveFile(&client, bucketName, "a.txt", "b.txt");
     /* 此方法展示如何复制七牛云存储的一个文件*/
-    demoCopyFile(&client, bucketName, "a.txt", "a_back.txt");
+    //demoCopyFile(&client, bucketName, "a.txt", "a_back.txt");
     /* 此方法展示如何删除七牛云存储的一个文件*/
-    demoDeleteFile(&client, bucketName, "a_back.txt");
+    //demoDeleteFile(&client, bucketName, "a_back.txt");
     /* 此方法展示如何批量的得到七牛云存储文件的信息*/
-    demoBatchStatFiles(&client, bucketName);
+    //demoBatchStatFiles(&client, bucketName);
     /* 此方法展示如何批量复制七牛云存储文件*/
-    demoBatchCopyFiles(&client, bucketName);
+    //demoBatchCopyFiles(&client, bucketName);
     /* 此方法展示如何批量删除七牛云存储文件*/
-    demoBatchDeleteFiles(&client, bucketName);
+    //demoBatchDeleteFiles(&client, bucketName);
 
     /* 此方法展示如何上传一个本地文件到服务器*/
-    demoUploadFile(&client, bucketName, &mac);
+    //demoUploadFile(&client, bucketName, &mac);
     /*此方法展示如何得到一个服务器上的文件的，下载url*/
-    demoGetDownloadURL(bucketName, &mac);
+    //demoGetDownloadURL(bucketName, &mac);
 
     // 反初始化
     Qiniu_Client_Cleanup(&client);

--- a/demo/gen_download_url_with_deadline.c
+++ b/demo/gen_download_url_with_deadline.c
@@ -1,0 +1,27 @@
+#include "../qiniu/cdn.h"
+#include "../qiniu/tm.h"
+
+int main(int argc, char * argv[])
+{
+    char * key = argv[1];
+    char * path = argv[2];
+    char * deadlineStr = argv[3];
+    char * encodedPath;
+    Qiniu_Uint64 deadline;
+
+    if (argc < 3) {
+        printf("Usage: gen_download_url_with_deadline <KEY> <URL> [DEADLINE]\n");
+        return 1;
+    } // if
+
+    if (deadlineStr) {
+        deadline = atol(deadlineStr);
+    } else {
+        deadline = Qiniu_Tm_LocalTime() + 3600;
+    } // if
+
+    encodedPath = Qiniu_Cdn_MakeDownloadUrlWithDeadline(key, path, deadline);
+    printf("%s\n", encodedPath);
+    Qiniu_Free(encodedPath);
+    return 0;
+}

--- a/demo/put_file.c
+++ b/demo/put_file.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../qiniu/rs.h"
+#include "../qiniu/io.h"
+#include "../qiniu/http.h"
+
+int main(int argc, char * argv[])
+{
+	Qiniu_Error err;
+	Qiniu_Client cli;
+	Qiniu_Mac mac;
+	Qiniu_Io_PutExtra extra;
+	Qiniu_Io_PutRet ret;
+	Qiniu_RS_PutPolicy pp;
+	const char * uptoken = NULL;
+	const char * bucket = NULL;
+	const char * key = NULL;
+	const char * localFile = NULL;
+
+	Qiniu_Global_Init(0);
+	Qiniu_Servend_Init(0);
+	Qiniu_MacAuth_Init();
+
+	memset(&extra, 0, sizeof(extra));
+	memset(&pp, 0, sizeof(pp));
+
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+	bucket = argv[3];
+	key = argv[4];
+	localFile = argv[5];
+
+	if (argc >= 7) {
+		extra.upHost = argv[6];
+	} // if
+
+	pp.scope = Qiniu_String_Format(512, "%s:%s", bucket, key);
+	uptoken = Qiniu_RS_PutPolicy_Token(&pp, &mac);
+
+	Qiniu_Client_InitNoAuth(&cli, 8192);
+
+	err = Qiniu_Io_PutFile(&cli, &ret, uptoken, key, localFile, &extra);
+	free((void*)uptoken);
+	free((void*)pp.scope);
+	printf("code=%d msg=[%s]\n", err.code, err.message);
+
+	Qiniu_Client_Cleanup(&cli);
+	Qiniu_MacAuth_Cleanup();
+	Qiniu_Servend_Cleanup();
+	Qiniu_Global_Cleanup();
+
+	if (err.code != 200) {
+		return 1;
+	} // if
+
+	return 0;
+} // main

--- a/demo/put_file_abortable.c
+++ b/demo/put_file_abortable.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "../qiniu/rs.h"
+#include "../qiniu/io.h"
+#include "../qiniu/http.h"
+
+static int offset = 0;
+static int sizeLimit = 0;
+
+int abortCallback(void * userData, char * buf, size_t size)
+{
+	int * offset = (int *) userData;
+	if ((*offset += size) >= sizeLimit) return 1;
+	return 0;
+}
+
+int main(int argc, char * argv[])
+{
+	Qiniu_Error err;
+	Qiniu_Client cli;
+	Qiniu_Mac mac;
+	Qiniu_Io_PutExtra extra;
+	Qiniu_Io_PutRet ret;
+	Qiniu_RS_PutPolicy pp;
+	const char * uptoken = NULL;
+	const char * bucket = NULL;
+	const char * key = NULL;
+	const char * localFile = NULL;
+
+	Qiniu_Global_Init(0);
+	Qiniu_Servend_Init(0);
+	Qiniu_MacAuth_Init();
+
+	Qiniu_Rgn_Disable();
+
+	memset(&extra, 0, sizeof(extra));
+	memset(&pp, 0, sizeof(pp));
+
+	if (argc < 6) {
+		printf("Usage: put_file_abortable <ACCESS_KEY> <SECRET_KEY> <BUCKET> <KEY> <LOCAL_FILE> [FILE_SIZE [MAX_FILE_SIZE]]\n");
+		return 1;
+	} // if
+
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+	bucket = argv[3];
+	key = argv[4];
+	localFile = argv[5];
+
+	if (argc >= 7) {
+		extra.upFileSize = atoi(argv[6]);
+	} // if
+
+	if (argc >= 8) {
+		sizeLimit = atoi(argv[7]);
+		extra.upAbortCallback = &abortCallback;
+		extra.upAbortUserData = &offset;
+	} // if
+
+	pp.scope = Qiniu_String_Format(512, "%s:%s", bucket, key);
+	uptoken = Qiniu_RS_PutPolicy_Token(&pp, &mac);
+
+	Qiniu_Client_InitNoAuth(&cli, 8192);
+
+	err = Qiniu_Io_PutFile(&cli, &ret, uptoken, key, localFile, &extra);
+	free((void*)uptoken);
+	free((void*)pp.scope);
+	printf("code=%d msg=[%s]\n", err.code, err.message);
+
+	Qiniu_Client_Cleanup(&cli);
+	Qiniu_MacAuth_Cleanup();
+	Qiniu_Servend_Cleanup();
+	Qiniu_Global_Cleanup();
+
+	if (err.code != 200) {
+		return 1;
+	} // if
+
+	return 0;
+} // main

--- a/demo/put_stream.c
+++ b/demo/put_stream.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <curl/curl.h>
+#include "../qiniu/rs.h"
+#include "../qiniu/io.h"
+#include "../qiniu/http.h"
+
+size_t rdr(char* buffer,size_t size,size_t n,void* fp)
+{
+    size_t nread = fread(buffer,size,n,fp);
+    if (nread==0) printf("READ DONE.\n");
+    return nread;
+}
+
+int main(int argc, char * argv[])
+{
+	Qiniu_Error err;
+	Qiniu_Client cli;
+	Qiniu_Mac mac;
+	Qiniu_Io_PutExtra extra;
+	Qiniu_Io_PutRet ret;
+	Qiniu_RS_PutPolicy pp;
+	const char * uptoken = NULL;
+	const char * bucket = NULL;
+	const char * key = NULL;
+	const char * localFile = NULL;
+
+	Qiniu_Global_Init(0);
+	Qiniu_Servend_Init(0);
+	Qiniu_MacAuth_Init();
+
+	memset(&extra, 0, sizeof(extra));
+	memset(&pp, 0, sizeof(pp));
+
+	mac.accessKey = argv[1];
+	mac.secretKey = argv[2];
+	bucket = argv[3];
+	key = argv[4];
+	localFile = argv[5];
+
+	if (argc >= 7) {
+		extra.upHost = argv[6];
+	} // if
+
+	pp.scope = Qiniu_String_Format(512, "%s:%s", bucket, key);
+	uptoken = Qiniu_RS_PutPolicy_Token(&pp, &mac);
+
+	Qiniu_Client_InitNoAuth(&cli, 8192);
+
+    struct stat fi;
+    stat(localFile, &fi);
+    size_t fsize = fi.st_size;
+    printf("fsize:%d\n",fsize);
+
+    FILE* fp = fopen(localFile,"rb");
+
+    err = Qiniu_Io_PutStream(&cli,&ret,uptoken,key,fp,fsize,rdr,&extra);
+
+    fclose(fp);
+
+	free((void*)uptoken);
+	free((void*)pp.scope);
+
+	printf("code:%d\nmsg:[%s]\n", err.code, err.message);
+
+	Qiniu_Client_Cleanup(&cli);
+	Qiniu_MacAuth_Cleanup();
+	Qiniu_Servend_Cleanup();
+	Qiniu_Global_Cleanup();
+
+	return 0;
+} // main

--- a/demo/put_stream.c
+++ b/demo/put_stream.c
@@ -5,11 +5,11 @@
 #include "../qiniu/io.h"
 #include "../qiniu/http.h"
 
-size_t rdr(char* buffer,size_t size,size_t n,void* fp)
+size_t rdr(char* buffer, size_t size, size_t n, void* fp)
 {
-    size_t nread = fread(buffer,size,n,fp);
-    if (nread==0) printf("READ DONE.\n");
-    return nread;
+	size_t nread = fread(buffer, size, n, fp);
+	if (nread == 0) printf("READ DONE.\n");
+	return nread;
 }
 
 int main(int argc, char * argv[])
@@ -47,16 +47,16 @@ int main(int argc, char * argv[])
 
 	Qiniu_Client_InitNoAuth(&cli, 8192);
 
-    struct stat fi;
-    stat(localFile, &fi);
-    size_t fsize = fi.st_size;
-    printf("fsize:%d\n",fsize);
+	struct stat fi;
+	stat(localFile, &fi);
+	size_t fsize = fi.st_size;
+	printf("fsize:%d\n", fsize);
 
-    FILE* fp = fopen(localFile,"rb");
+	FILE* fp = fopen(localFile, "rb");
 
-    err = Qiniu_Io_PutStream(&cli,&ret,uptoken,key,fp,fsize,rdr,&extra);
+	err = Qiniu_Io_PutStream(&cli, &ret, uptoken, key, fp, fsize, rdr, &extra);
 
-    fclose(fp);
+	fclose(fp);
 
 	free((void*)uptoken);
 	free((void*)pp.scope);

--- a/qiniu/auth_mac.c
+++ b/qiniu/auth_mac.c
@@ -10,7 +10,7 @@
 #include "http.h"
 #include <curl/curl.h>
 #include <openssl/hmac.h>
-#include<openssl/engine.h>
+#include <openssl/engine.h>
 
 #if defined(_WIN32)
 #pragma comment(lib, "libeay32.lib")
@@ -78,7 +78,7 @@ static Qiniu_Error Qiniu_Mac_Auth(
 
 	if (addlen > 0) {
 		HMAC_Update(&ctx, addition, addlen);
-	}
+	} 
 
 	HMAC_Final(&ctx, digest, &dgtlen);
 	HMAC_CTX_cleanup(&ctx);

--- a/qiniu/base.c
+++ b/qiniu/base.c
@@ -226,6 +226,7 @@ char* Qiniu_String_Join(const char* deli, char* strs[], int strCount)
 	int i = 0;
 	char * ret = NULL;
 	char * pos = NULL;
+	char * tmpRet = NULL;
 	size_t totalLen = 0;
 	size_t copyLen = 0;
 	size_t deliLen = 0;

--- a/qiniu/base.h
+++ b/qiniu/base.h
@@ -15,14 +15,12 @@
 #include <string.h>
 #include <stdarg.h>
 
+#include "macro.h"
+
 /*============================================================================*/
 /* func type ssize_t */
 
 #ifdef _WIN32
-
-#ifndef QINIU_EXPORTS
-#pragma comment(lib, "qiniu.lib")
-#endif
 
 #include <sys/types.h>
 
@@ -101,7 +99,7 @@ typedef struct _Qiniu_Error {
 
 /* @endgist */
 
-extern Qiniu_Error Qiniu_OK;
+QINIU_DLLAPI extern Qiniu_Error Qiniu_OK;
 
 /*============================================================================*/
 /* type Qiniu_Free */
@@ -113,27 +111,27 @@ void Qiniu_Free(void* addr);
 
 typedef long Qiniu_Count;
 
-Qiniu_Count Qiniu_Count_Inc(Qiniu_Count* self);
-Qiniu_Count Qiniu_Count_Dec(Qiniu_Count* self);
+QINIU_DLLAPI extern Qiniu_Count Qiniu_Count_Inc(Qiniu_Count* self);
+QINIU_DLLAPI extern Qiniu_Count Qiniu_Count_Dec(Qiniu_Count* self);
 
 /*============================================================================*/
 /* func Qiniu_String_Concat */
 
-char* Qiniu_String_Concat2(const char* s1, const char* s2);
-char* Qiniu_String_Concat3(const char* s1, const char* s2, const char* s3);
-char* Qiniu_String_Concat(const char* s1, ...);
+QINIU_DLLAPI extern char* Qiniu_String_Concat2(const char* s1, const char* s2);
+QINIU_DLLAPI extern char* Qiniu_String_Concat3(const char* s1, const char* s2, const char* s3);
+QINIU_DLLAPI extern char* Qiniu_String_Concat(const char* s1, ...);
 
-char* Qiniu_String_Format(size_t initSize, const char* fmt, ...);
+QINIU_DLLAPI extern char* Qiniu_String_Format(size_t initSize, const char* fmt, ...);
 
-char* Qiniu_String_Join(const char* deli, char* strs[], int strCount);
-char* Qiniu_String_Dup(const char* src);
+QINIU_DLLAPI extern char* Qiniu_String_Join(const char* deli, char* strs[], int strCount);
+QINIU_DLLAPI extern char* Qiniu_String_Dup(const char* src);
 
 /*============================================================================*/
 /* func Qiniu_String_Encode */
 
-char* Qiniu_Memory_Encode(const char* buf, const size_t cb);
-char* Qiniu_String_Encode(const char* s);
-char* Qiniu_String_Decode(const char* s);
+QINIU_DLLAPI extern char* Qiniu_Memory_Encode(const char* buf, const size_t cb);
+QINIU_DLLAPI extern char* Qiniu_String_Encode(const char* s);
+QINIU_DLLAPI extern char* Qiniu_String_Decode(const char* s);
 
 /*============================================================================*/
 /* func Qiniu_QueryEscape */
@@ -156,7 +154,7 @@ typedef struct _Qiniu_Reader {
 	Qiniu_FnRead Read;
 } Qiniu_Reader;
 
-Qiniu_Reader Qiniu_FILE_Reader(FILE* fp);
+QINIU_DLLAPI extern Qiniu_Reader Qiniu_FILE_Reader(FILE* fp);
 
 /*============================================================================*/
 /* type Qiniu_Writer */
@@ -168,8 +166,8 @@ typedef struct _Qiniu_Writer {
 	Qiniu_FnWrite Write;
 } Qiniu_Writer;
 
-Qiniu_Writer Qiniu_FILE_Writer(FILE* fp);
-Qiniu_Error Qiniu_Copy(Qiniu_Writer w, Qiniu_Reader r, void* buf, size_t n, Qiniu_Int64* ret);
+QINIU_DLLAPI extern Qiniu_Writer Qiniu_FILE_Writer(FILE* fp);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Copy(Qiniu_Writer w, Qiniu_Reader r, void* buf, size_t n, Qiniu_Int64* ret);
 
 #define Qiniu_Stderr Qiniu_FILE_Writer(stderr)
 
@@ -196,40 +194,40 @@ typedef struct _Qiniu_Buffer {
 	char* bufEnd;
 } Qiniu_Buffer;
 
-void Qiniu_Buffer_Init(Qiniu_Buffer* self, size_t initSize);
-void Qiniu_Buffer_Reset(Qiniu_Buffer* self);
-void Qiniu_Buffer_AppendInt(Qiniu_Buffer* self, Qiniu_Int64 v);
-void Qiniu_Buffer_AppendUint(Qiniu_Buffer* self, Qiniu_Uint64 v);
-void Qiniu_Buffer_AppendError(Qiniu_Buffer* self, Qiniu_Error v);
-void Qiniu_Buffer_AppendEncodedBinary(Qiniu_Buffer* self, const char* buf, size_t cb);
-void Qiniu_Buffer_AppendFormat(Qiniu_Buffer* self, const char* fmt, ...);
-void Qiniu_Buffer_AppendFormatV(Qiniu_Buffer* self, const char* fmt, Qiniu_Valist* args);
-void Qiniu_Buffer_Cleanup(Qiniu_Buffer* self);
+QINIU_DLLAPI extern void Qiniu_Buffer_Init(Qiniu_Buffer* self, size_t initSize);
+QINIU_DLLAPI extern void Qiniu_Buffer_Reset(Qiniu_Buffer* self);
+QINIU_DLLAPI extern void Qiniu_Buffer_AppendInt(Qiniu_Buffer* self, Qiniu_Int64 v);
+QINIU_DLLAPI extern void Qiniu_Buffer_AppendUint(Qiniu_Buffer* self, Qiniu_Uint64 v);
+QINIU_DLLAPI extern void Qiniu_Buffer_AppendError(Qiniu_Buffer* self, Qiniu_Error v);
+QINIU_DLLAPI extern void Qiniu_Buffer_AppendEncodedBinary(Qiniu_Buffer* self, const char* buf, size_t cb);
+QINIU_DLLAPI extern void Qiniu_Buffer_AppendFormat(Qiniu_Buffer* self, const char* fmt, ...);
+QINIU_DLLAPI extern void Qiniu_Buffer_AppendFormatV(Qiniu_Buffer* self, const char* fmt, Qiniu_Valist* args);
+QINIU_DLLAPI extern void Qiniu_Buffer_Cleanup(Qiniu_Buffer* self);
 
-const char* Qiniu_Buffer_CStr(Qiniu_Buffer* self);
-const char* Qiniu_Buffer_Format(Qiniu_Buffer* self, const char* fmt, ...);
+QINIU_DLLAPI extern const char* Qiniu_Buffer_CStr(Qiniu_Buffer* self);
+QINIU_DLLAPI extern const char* Qiniu_Buffer_Format(Qiniu_Buffer* self, const char* fmt, ...);
 
-void Qiniu_Buffer_PutChar(Qiniu_Buffer* self, char ch);
+QINIU_DLLAPI extern void Qiniu_Buffer_PutChar(Qiniu_Buffer* self, char ch);
 
-size_t Qiniu_Buffer_Len(Qiniu_Buffer* self);
-size_t Qiniu_Buffer_Write(Qiniu_Buffer* self, const void* buf, size_t n);
-size_t Qiniu_Buffer_Fwrite(const void* buf, size_t, size_t n, void* self);
+QINIU_DLLAPI extern size_t Qiniu_Buffer_Len(Qiniu_Buffer* self);
+QINIU_DLLAPI extern size_t Qiniu_Buffer_Write(Qiniu_Buffer* self, const void* buf, size_t n);
+QINIU_DLLAPI extern size_t Qiniu_Buffer_Fwrite(const void* buf, size_t, size_t n, void* self);
 
-Qiniu_Writer Qiniu_BufWriter(Qiniu_Buffer* self);
+QINIU_DLLAPI extern Qiniu_Writer Qiniu_BufWriter(Qiniu_Buffer* self);
 
-char* Qiniu_Buffer_Expand(Qiniu_Buffer* self, size_t n);
-void Qiniu_Buffer_Commit(Qiniu_Buffer* self, char* p);
+QINIU_DLLAPI extern char* Qiniu_Buffer_Expand(Qiniu_Buffer* self, size_t n);
+QINIU_DLLAPI extern void Qiniu_Buffer_Commit(Qiniu_Buffer* self, char* p);
 
 typedef void (*Qiniu_FnAppender)(Qiniu_Buffer* self, Qiniu_Valist* ap);
 
-void Qiniu_Format_Register(char esc, Qiniu_FnAppender appender);
+QINIU_DLLAPI extern void Qiniu_Format_Register(char esc, Qiniu_FnAppender appender);
 
 /*============================================================================*/
 /* func Qiniu_Null_Fwrite */
 
-size_t Qiniu_Null_Fwrite(const void* buf, size_t, size_t n, void* self);
+QINIU_DLLAPI extern size_t Qiniu_Null_Fwrite(const void* buf, size_t, size_t n, void* self);
 
-extern Qiniu_Writer Qiniu_Discard;
+QINIU_DLLAPI extern Qiniu_Writer Qiniu_Discard;
 
 /*============================================================================*/
 /* type Qiniu_ReadBuf */
@@ -240,8 +238,8 @@ typedef struct _Qiniu_ReadBuf {
 	Qiniu_Off_T limit;
 } Qiniu_ReadBuf;
 
-Qiniu_Reader Qiniu_BufReader(Qiniu_ReadBuf* self, const char* buf, size_t bytes);
-Qiniu_ReaderAt Qiniu_BufReaderAt(Qiniu_ReadBuf* self, const char* buf, size_t bytes);
+QINIU_DLLAPI extern Qiniu_Reader Qiniu_BufReader(Qiniu_ReadBuf* self, const char* buf, size_t bytes);
+QINIU_DLLAPI extern Qiniu_ReaderAt Qiniu_BufReaderAt(Qiniu_ReadBuf* self, const char* buf, size_t bytes);
 
 /*============================================================================*/
 /* type Qiniu_Tee */
@@ -251,7 +249,7 @@ typedef struct _Qiniu_Tee {
 	Qiniu_Writer w;
 } Qiniu_Tee;
 
-Qiniu_Reader Qiniu_TeeReader(Qiniu_Tee* self, Qiniu_Reader r, Qiniu_Writer w);
+QINIU_DLLAPI extern Qiniu_Reader Qiniu_TeeReader(Qiniu_Tee* self, Qiniu_Reader r, Qiniu_Writer w);
 
 /*============================================================================*/
 /* type Qiniu_Section */
@@ -262,18 +260,18 @@ typedef struct _Qiniu_Section {
 	Qiniu_Off_T limit;
 } Qiniu_Section;
 
-Qiniu_Reader Qiniu_SectionReader(Qiniu_Section* self, Qiniu_ReaderAt r, Qiniu_Off_T off, size_t n);
+QINIU_DLLAPI extern Qiniu_Reader Qiniu_SectionReader(Qiniu_Section* self, Qiniu_ReaderAt r, Qiniu_Off_T off, size_t n);
 
 /*============================================================================*/
 /* type Qiniu_Crc32 */
 
-unsigned long Qiniu_Crc32_Update(unsigned long inCrc32, const void *buf, size_t bufLen);
+QINIU_DLLAPI extern unsigned long Qiniu_Crc32_Update(unsigned long inCrc32, const void *buf, size_t bufLen);
 
 typedef struct _Qiniu_Crc32 {
 	unsigned long val;
 } Qiniu_Crc32;
 
-Qiniu_Writer Qiniu_Crc32Writer(Qiniu_Crc32* self, unsigned long inCrc32);
+QINIU_DLLAPI extern Qiniu_Writer Qiniu_Crc32Writer(Qiniu_Crc32* self, unsigned long inCrc32);
 
 /*============================================================================*/
 /* type Qiniu_File */
@@ -288,19 +286,23 @@ typedef struct _Qiniu_FileInfo {
 	time_t          st_ctime;   /* time of last status change */
 } Qiniu_FileInfo;
 #else
+
+#include <sys/stat.h>
+
 typedef struct stat Qiniu_FileInfo;
+
 #endif
 
-Qiniu_Error Qiniu_File_Open(Qiniu_File** pp, const char* file);
-Qiniu_Error Qiniu_File_Stat(Qiniu_File* self, Qiniu_FileInfo* fi);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_File_Open(Qiniu_File** pp, const char* file);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_File_Stat(Qiniu_File* self, Qiniu_FileInfo* fi);
 
 #define Qiniu_FileInfo_Fsize(fi) ((fi).st_size)
 
-void Qiniu_File_Close(void* self);
+QINIU_DLLAPI extern void Qiniu_File_Close(void* self);
 
-ssize_t Qiniu_File_ReadAt(void* self, void *buf, size_t bytes, Qiniu_Off_T offset);
+QINIU_DLLAPI extern ssize_t Qiniu_File_ReadAt(void* self, void *buf, size_t bytes, Qiniu_Off_T offset);
 
-Qiniu_ReaderAt Qiniu_FileReaderAt(Qiniu_File* self);
+QINIU_DLLAPI extern Qiniu_ReaderAt Qiniu_FileReaderAt(Qiniu_File* self);
 
 /*============================================================================*/
 /* type Qiniu_Log */
@@ -312,12 +314,12 @@ Qiniu_ReaderAt Qiniu_FileReaderAt(Qiniu_File* self);
 #define Qiniu_Lpanic	4
 #define Qiniu_Lfatal	5
 
-void Qiniu_Logv(Qiniu_Writer w, int level, const char* fmt, Qiniu_Valist* args);
+QINIU_DLLAPI extern void Qiniu_Logv(Qiniu_Writer w, int level, const char* fmt, Qiniu_Valist* args);
 
-void Qiniu_Stderr_Info(const char* fmt, ...);
-void Qiniu_Stderr_Warn(const char* fmt, ...);
+QINIU_DLLAPI extern void Qiniu_Stderr_Info(const char* fmt, ...);
+QINIU_DLLAPI extern void Qiniu_Stderr_Warn(const char* fmt, ...);
 
-void Qiniu_Null_Log(const char* fmt, ...);
+QINIU_DLLAPI extern void Qiniu_Null_Log(const char* fmt, ...);
 
 #ifndef Qiniu_Log_Info
 

--- a/qiniu/base_io.c
+++ b/qiniu/base_io.c
@@ -12,8 +12,12 @@
 #include <sys/stat.h>
 #include <errno.h>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 #ifdef _WIN32
-#include "../../c-sdk-wdeps/emu-posix/emu_posix.h" // for type Qiniu_Posix_File
+#include "../windows/emu_posix.h" // for type Qiniu_Posix_File
 #else
 #include <unistd.h>
 #define Qiniu_Posix_Handle	int
@@ -87,7 +91,7 @@ unsigned long Qiniu_Crc32_Update(unsigned long inCrc32, const void *buf, size_t 
 	return crc32 ^ 0xFFFFFFFF;
 }
 
-size_t Qiniu_Crc32_Fwrite(const void* buf, size_t cbelem, size_t n, Qiniu_Crc32* self)
+static size_t Qiniu_Crc32_Fwrite(const void* buf, size_t cbelem, size_t n, Qiniu_Crc32* self)
 {
 	self->val = Qiniu_Crc32_Update(self->val, buf, n);
 	return n;
@@ -117,7 +121,7 @@ static size_t Qiniu_ReadBuf_Read(void *buf, size_t unused, size_t n, Qiniu_ReadB
 	return n;
 }
 
-ssize_t Qiniu_ReadBuf_ReadAt(Qiniu_ReadBuf* self, void *buf, size_t n, Qiniu_Off_T off)
+static ssize_t Qiniu_ReadBuf_ReadAt(Qiniu_ReadBuf* self, void *buf, size_t n, Qiniu_Off_T off)
 {
 	Qiniu_Int64 max = self->limit - off;
 	if (max <= 0) {
@@ -151,7 +155,7 @@ Qiniu_ReaderAt Qiniu_BufReaderAt(Qiniu_ReadBuf* self, const char* buf, size_t by
 /*============================================================================*/
 /* type Qiniu_Section */
 
-size_t Qiniu_Section_Read(void* buf, size_t unused, size_t n, Qiniu_Section* self)
+static size_t Qiniu_Section_Read(void* buf, size_t unused, size_t n, Qiniu_Section* self)
 {
 	Qiniu_Int64 max = 0;
 	ssize_t readBytes = 0;
@@ -184,7 +188,7 @@ Qiniu_Reader Qiniu_SectionReader(Qiniu_Section* self, Qiniu_ReaderAt r, Qiniu_Of
 /*============================================================================*/
 /* type Qiniu_Tee */
 
-size_t Qiniu_Tee_Read(void* buf, size_t unused, size_t n, Qiniu_Tee* self)
+static size_t Qiniu_Tee_Read(void* buf, size_t unused, size_t n, Qiniu_Tee* self)
 {
 	size_t nr = self->r.Read(buf, unused, n, self->r.self);
 	if (nr > 0) {
@@ -240,7 +244,7 @@ int Qiniu_Posix_Fstat(Qiniu_Posix_Handle fd, Qiniu_FileInfo* fi)
 	return 0;
 }
 
-#endif
+#else
 
 Qiniu_Error Qiniu_File_Stat(Qiniu_File* self, Qiniu_FileInfo* fi)
 {
@@ -249,10 +253,15 @@ Qiniu_Error Qiniu_File_Stat(Qiniu_File* self, Qiniu_FileInfo* fi)
 		err.code = errno;
 		err.message = "fstat failed";
 	} else {
+#if defined(__APPLE__) && defined(TARGET_OS_MAC)
+		fi->st_size >>= 32;
+#endif
 		err = Qiniu_OK;
 	}
 	return err;
 }
+
+#endif
 
 void Qiniu_File_Close(void* self)
 {

--- a/qiniu/cdn.c
+++ b/qiniu/cdn.c
@@ -181,7 +181,6 @@ QINIU_DLLAPI char * Qiniu_Cdn_MakeDownloadUrlWithDeadline(const char * key, cons
 	return authedUrl;
 }
 
-// TODO: Parse `ret->invalidUrls` and `ret->invalidDirs` fields
 QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshUrls(Qiniu_Client*self, Qiniu_Cdn_RefreshRet* ret, const char* urls[], const int num)
 {
 	Qiniu_Error err;
@@ -201,15 +200,7 @@ QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshUrls(Qiniu_Client*self, Qiniu_Cdn_Refr
 		self, &jsonRet, url, body, strlen(body), "application/json");
 
 	if (err.code == 200) {
-		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-		ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
-		//ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
-		//ret->invalidDirs = Qiniu_Json_GetObjectItem(jsonRet, "invalidDirs", "");
-		ret->urlQuotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
-		ret->urlSurplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
-		ret->dirQuotaDay = Qiniu_Json_GetInt(jsonRet, "dirQuotaDay", 0);
-		ret->dirSurplusDay = Qiniu_Json_GetInt(jsonRet, "dirSurplusDay", 0);
+		err = Qiniu_Parse_CdnRefreshRet(jsonRet, ret);
 	}
 
 	Qiniu_Free(url);
@@ -219,7 +210,6 @@ QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshUrls(Qiniu_Client*self, Qiniu_Cdn_Refr
 	return err;
 }
 
-// TODO: Parse `ret->invalidUrls` and `ret->invalidDirs` fields
 QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshDirs(Qiniu_Client*self, Qiniu_Cdn_RefreshRet* ret, const char* dirs[], const int num)
 {
 	Qiniu_Error err;
@@ -239,15 +229,7 @@ QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshDirs(Qiniu_Client*self, Qiniu_Cdn_Refr
 		self, &jsonRet, url, body, strlen(body), "application/json");
 
 	if (err.code == 200) {
-		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-		ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
-		//ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
-		//ret->invalidDirs = Qiniu_Json_GetObjectItem(jsonRet, "invalidDirs", "");
-		ret->urlQuotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
-		ret->urlSurplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
-		ret->dirQuotaDay = Qiniu_Json_GetInt(jsonRet, "dirQuotaDay", 0);
-		ret->dirSurplusDay = Qiniu_Json_GetInt(jsonRet, "dirSurplusDay", 0);
+		err = Qiniu_Parse_CdnRefreshRet(jsonRet, ret);
 	}
 
 	Qiniu_Free(url);
@@ -257,7 +239,6 @@ QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshDirs(Qiniu_Client*self, Qiniu_Cdn_Refr
 	return err;
 }
 
-// TODO: Parse `ret->invalidUrls` field
 QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_PrefetchUrls(Qiniu_Client*self, Qiniu_Cdn_PrefetchRet* ret, const char* urls[], const int num)
 {
 	Qiniu_Error err;
@@ -277,12 +258,7 @@ QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_PrefetchUrls(Qiniu_Client*self, Qiniu_Cdn_Pre
 
 
 	if (err.code == 200) {
-		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-		ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
-		//ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
-		ret->quotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
-		ret->surplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
+		err = Qiniu_Parse_CdnPrefetchRet(jsonRet, ret);
 	}
 
 	Qiniu_Free(url);
@@ -292,10 +268,9 @@ QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_PrefetchUrls(Qiniu_Client*self, Qiniu_Cdn_Pre
 	return err;
 }
 
-// TODO: Parse `ret->time` and `ret->data` fields
 QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetFluxData(
 	Qiniu_Client* self,
-	Qiniu_Cdn_FluxBandwidthRet* ret,
+	Qiniu_Cdn_FluxRet* ret,
 	const char* startDate,
 	const char* endDate,
 	const char* granularity,
@@ -321,26 +296,21 @@ QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetFluxData(
 	err = Qiniu_Client_CallWithBuffer2(
 		self, &jsonRet, url, body, strlen(body), "application/json");
 
-
 	if (err.code == 200) {
-		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-		//ret->time = Qiniu_Json_GetString(jsonRet, "time", "");
-		//ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+		err = Qiniu_Parse_CdnFluxRet(jsonRet, ret, domains, num);
 	}
 
 	Qiniu_Free(url);
-	//Qiniu_Free(domains_str);
+	Qiniu_Free(domains_str);
 	Qiniu_Free(body);
 	cJSON_Delete(root);
 
 	return err;
 }
 
-// TODO: Parse `ret->time` and `ret->data` fields
 QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetBandwidthData(
 	Qiniu_Client* self,
-	Qiniu_Cdn_FluxBandwidthRet* ret,
+	Qiniu_Cdn_BandwidthRet* ret,
 	const char* startDate,
 	const char* endDate,
 	const char* granularity,
@@ -368,10 +338,7 @@ QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetBandwidthData(
 
 
 	if (err.code == 200) {
-		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-		//ret->time = Qiniu_Json_GetString(jsonRet, "time", "");
-		//ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+		err = Qiniu_Parse_CdnBandwidthRet(jsonRet, ret, domains, num);
 	}
 
 	Qiniu_Free(url);
@@ -382,7 +349,6 @@ QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetBandwidthData(
 	return err;
 }
 
-// TODO: Parse `ret->data` field
 QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetLogList(
 	Qiniu_Client* self,
 	Qiniu_Cdn_LogListRet* ret,
@@ -409,9 +375,7 @@ QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetLogList(
 
 
 	if (err.code == 200) {
-		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-		//ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+		err = Qiniu_Parse_CdnLogListRet(jsonRet, ret, domains, num);
 	}
 
 	Qiniu_Free(url);
@@ -420,4 +384,379 @@ QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetLogList(
 	cJSON_Delete(root);
 
 	return err;
+}
+
+QINIU_DLLAPI Qiniu_Error Qiniu_Parse_CdnRefreshRet(Qiniu_Json* root, Qiniu_Cdn_RefreshRet* ret)
+{
+	Qiniu_Error err;
+
+	ret->code = Qiniu_Json_GetInt(root, "code", 0);
+	ret->error = Qiniu_Json_GetString(root, "error", "");
+	ret->requestId = Qiniu_Json_GetString(root, "requestId", "");
+
+	cJSON* iur = cJSON_GetObjectItem(root, "invalidUrls");
+	int iun = cJSON_GetArraySize(iur);
+	ret->invalidUrls = (char**)calloc(256, iun);
+	for (int i = 0; i < iun; ++i) {
+		strcat(ret->invalidUrls, cJSON_GetArrayItem(iur, i)->valuestring);
+		if (i < iun - 1) strcat(ret->invalidUrls, " ");
+	}
+
+	cJSON* idr = cJSON_GetObjectItem(root, "invalidDirs");
+	int idn = cJSON_GetArraySize(idr);
+	ret->invalidDirs = (char**)calloc(256, idn);
+	for (int i = 0; i < idn; ++i) {
+		strcat(ret->invalidDirs, cJSON_GetArrayItem(idr, i)->valuestring);
+		if (i < idn - 1) strcat(ret->invalidDirs, " ");
+	}
+
+	ret->urlQuotaDay = Qiniu_Json_GetInt(root, "urlQuotaDay", 0);
+	ret->urlSurplusDay = Qiniu_Json_GetInt(root, "urlSurplusDay", 0);
+	ret->dirQuotaDay = Qiniu_Json_GetInt(root, "dirQuotaDay", 0);
+	ret->dirSurplusDay = Qiniu_Json_GetInt(root, "dirSurplusDay", 0);
+
+	err.code = 200;
+	err.message = "OK";
+
+	return err;
+}
+
+QINIU_DLLAPI Qiniu_Error Qiniu_Parse_CdnPrefetchRet(Qiniu_Json* root, Qiniu_Cdn_PrefetchRet* ret)
+{
+	Qiniu_Error err;
+
+	ret->code = Qiniu_Json_GetInt(root, "code", 0);
+	ret->error = Qiniu_Json_GetString(root, "error", "");
+	ret->requestId = Qiniu_Json_GetString(root, "requestId", "");
+
+	cJSON* iur = cJSON_GetObjectItem(root, "invalidUrls");
+	int iun = cJSON_GetArraySize(iur);
+	ret->invalidUrls = (char**)calloc(256, iun);
+	for (int i = 0; i < iun; ++i) {
+		strcat(ret->invalidUrls, cJSON_GetArrayItem(iur, i)->valuestring);
+		if (i < iun - 1) strcat(ret->invalidUrls, " ");
+	}
+
+	ret->quotaDay = Qiniu_Json_GetInt(root, "quotaDay", 0);
+	ret->surplusDay = Qiniu_Json_GetInt(root, "surplusDay", 0);
+
+	err.code = 200;
+	err.message = "OK";
+
+	return err;
+}
+
+QINIU_DLLAPI Qiniu_Error Qiniu_Parse_CdnFluxRet(Qiniu_Json* root, Qiniu_Cdn_FluxRet* ret, const char* domains[], const int num)
+{
+	Qiniu_Error err;
+
+	ret->code = Qiniu_Json_GetInt(root, "code", 0);
+	ret->error = Qiniu_Json_GetString(root, "error", "");
+	ret->num = num;
+	ret->data_a = (Qiniu_Cdn_FluxData*)malloc(sizeof(Qiniu_Cdn_FluxData)*num);
+
+	cJSON* tr = cJSON_GetObjectItem(root, "time");
+	if (tr == NULL) {
+		err.code = 9999;
+		err.message = "Failed to parse cdn-flux-ret-time";
+		return err;
+	}
+
+	cJSON* dr = cJSON_GetObjectItem(root, "data");
+	if (dr == NULL) {
+		err.code = 9999;
+		err.message = "Failed to parse cdn cdn-flux-ret-data";
+		return err;
+	}
+
+	int count = cJSON_GetArraySize(tr);
+
+	for (int i = 0; i < num; ++i) {
+		cJSON* item = cJSON_GetObjectItem(dr, domains[i]);
+		if (item == NULL) {
+			ret->data_a[i].hasValue = FALSE;
+			ret->data_a[i].count = 0;
+			continue;
+		}
+
+		ret->data_a[i].hasValue = TRUE;
+		ret->data_a[i].count = count;
+
+		ret->data_a[i].domain = (char*)calloc(256, 1);
+		strcpy(ret->data_a[i].domain, domains[i]);
+
+		ret->data_a[i].item_a = (Qiniu_Cdn_FluxDataItem*)malloc(sizeof(Qiniu_Cdn_FluxDataItem)*count);
+
+		for (int j = 0; j < count; ++j) {
+			ret->data_a[i].item_a[j].time = (char*)calloc(64, 1);
+			strcpy(ret->data_a[i].item_a[j].time, cJSON_GetArrayItem(tr, j)->valuestring);
+		}
+
+		cJSON* item_china = cJSON_GetObjectItem(item, "china");
+		if (item_china != NULL) {
+			for (int j = 0; j < count; ++j) {
+				cJSON* v = cJSON_GetArrayItem(item_china, j);
+				if (v != NULL) {
+					ret->data_a[i].item_a[j].val_china = v->valueint;
+				}
+				else {
+					ret->data_a[i].item_a[j].val_china = 0;
+				}
+			}
+		}
+		else
+		{
+			for (int j = 0; j < count; ++j) {
+				ret->data_a[i].item_a[j].val_china = 0;
+			}
+		}
+
+		cJSON* item_oversea = cJSON_GetObjectItem(item, "oversea");
+		if (item_oversea != NULL) {
+			for (int j = 0; j < count; ++j) {
+				cJSON* v = cJSON_GetArrayItem(item_oversea, j);
+				if (v != NULL) {
+					ret->data_a[i].item_a[j].val_oversea = v->valueint;
+				}
+				else {
+					ret->data_a[i].item_a[j].val_oversea = 0;
+				}
+			}
+		}
+		else
+		{
+			for (int j = 0; j < count; ++j) {
+				ret->data_a[i].item_a[j].val_oversea = 0;
+			}
+		}
+	}
+
+	err.code = 200;
+	err.message = "OK";
+
+	return err;
+}
+
+QINIU_DLLAPI Qiniu_Error Qiniu_Parse_CdnBandwidthRet(Qiniu_Json* root, Qiniu_Cdn_BandwidthRet* ret, const char* domains[], const int num)
+{
+	Qiniu_Error err;
+
+	ret->code = Qiniu_Json_GetInt(root, "code", 0);
+	ret->error = Qiniu_Json_GetString(root, "error", "");
+	ret->num = num;
+	ret->data_a = (Qiniu_Cdn_BandwidthData*)malloc(sizeof(Qiniu_Cdn_BandwidthData)*num);
+
+	cJSON* tr = cJSON_GetObjectItem(root, "time");
+	if (tr == NULL) {
+		err.code = 9999;
+		err.message = "Failed to parse cdn time";
+		return err;
+	}
+
+	cJSON* dr = cJSON_GetObjectItem(root, "data");
+	if (dr == NULL) {
+		err.code = 9999;
+		err.message = "Failed to parse cdn data";
+		return err;
+	}
+
+	int count = cJSON_GetArraySize(tr);
+
+	for (int i = 0; i < num; ++i) {
+		cJSON* item = cJSON_GetObjectItem(dr, domains[i]);
+		if (item == NULL) {
+			ret->data_a[i].hasValue = FALSE;
+			ret->data_a[i].count = 0;
+			continue;
+		}
+
+		ret->data_a[i].hasValue = TRUE;
+		ret->data_a[i].count = count;
+
+		ret->data_a[i].domain = (char*)calloc(256, 1);
+		strcpy(ret->data_a[i].domain, domains[i]);
+
+		ret->data_a[i].item_a = (Qiniu_Cdn_FluxDataItem*)malloc(sizeof(Qiniu_Cdn_FluxDataItem)*count);
+
+		for (int j = 0; j < count; ++j) {
+			ret->data_a[i].item_a[j].time = (char*)calloc(64, 1);
+			strcpy(ret->data_a[i].item_a[j].time, cJSON_GetArrayItem(tr, j)->valuestring);
+		}
+
+		cJSON* item_china = cJSON_GetObjectItem(item, "china");
+		if (item_china != NULL) {
+			for (int j = 0; j < count; ++j) {
+				cJSON* v = cJSON_GetArrayItem(item_china, j);
+				if (v != NULL) {
+					ret->data_a[i].item_a[j].val_china = v->valueint;
+				}
+				else {
+					ret->data_a[i].item_a[j].val_china = 0;
+				}
+			}
+		}
+		else
+		{
+			for (int j = 0; j < count; ++j) {
+				ret->data_a[i].item_a[j].val_china = 0;
+			}
+		}
+
+		cJSON* item_oversea = cJSON_GetObjectItem(item, "oversea");
+		if (item_oversea != NULL) {
+			for (int j = 0; j < count; ++j) {
+				cJSON* v = cJSON_GetArrayItem(item_oversea, j);
+				if (v != NULL) {
+					ret->data_a[i].item_a[j].val_oversea = v->valueint;
+				}
+				else {
+					ret->data_a[i].item_a[j].val_oversea = 0;
+				}
+			}
+		}
+		else
+		{
+			for (int j = 0; j < count; ++j) {
+				ret->data_a[i].item_a[j].val_oversea = 0;
+			}
+		}
+	}
+
+	err.code = 200;
+	err.message = "OK";
+
+	return err;
+}
+
+QINIU_DLLAPI Qiniu_Error Qiniu_Parse_CdnLogListRet(Qiniu_Json* root, Qiniu_Cdn_LogListRet* ret, const char* domains[], const int num)
+{
+	Qiniu_Error err;
+
+	ret->code = Qiniu_Json_GetInt(root, "code", 0);
+	ret->error = Qiniu_Json_GetString(root, "error", "");
+	ret->num = num;
+
+	cJSON* dr = cJSON_GetObjectItem(root, "data");
+	if (dr == NULL) {
+		err.code = 9999;
+		err.message = "Failed to parse cdn data";
+		return err;
+	}
+
+	ret->data_a = (Qiniu_Cdn_LogListData*)malloc(sizeof(Qiniu_Cdn_LogListData)*num);
+
+	for (int i = 0; i < num; ++i) {
+		cJSON* item = cJSON_GetObjectItem(dr, domains[i]);
+		if (item == NULL) {
+			ret->data_a[i].hasValue = FALSE;
+			ret->data_a[i].count = 0;
+			continue;
+		}
+
+		int count = cJSON_GetArraySize(item);
+		if (count == 0) {
+			ret->data_a[i].hasValue = FALSE;
+			ret->data_a[i].count = 0;
+			continue;
+		}
+
+		ret->data_a[i].hasValue = TRUE;
+		ret->data_a[i].domain = (char*)calloc(256, 1);
+		strcpy(ret->data_a[i].domain, domains[i]);
+
+		ret->data_a[i].count = count;
+
+		ret->data_a[i].item_a = (Qiniu_Cdn_LogListDataItem*)malloc(sizeof(Qiniu_Cdn_LogListDataItem)*count);
+		for (int j = 0; j < count; ++j) {
+			cJSON* sub = cJSON_GetArrayItem(item, j);
+			ret->data_a[i].item_a[j].name = (char*)calloc(1024, 1);
+			strcpy(ret->data_a[i].item_a[j].name, cJSON_GetObjectItem(sub, "name")->valuestring);
+
+			ret->data_a[i].item_a[j].size = Qiniu_Json_GetInt(sub, "size", 0);
+			ret->data_a[i].item_a[j].mtime = Qiniu_Json_GetInt(sub, "mtime", 0);
+
+			ret->data_a[i].item_a[j].url = (char*)calloc(1024, 1);
+			strcpy(ret->data_a[i].item_a[j].url, cJSON_GetObjectItem(sub, "url")->valuestring);
+		}
+	}
+
+	err.code = 200;
+	err.message = "OK";
+	return err;
+}
+
+QINIU_DLLAPI void Qiniu_Free_CdnRefreshRet(Qiniu_Cdn_RefreshRet* ret)
+{
+	free(ret->error);
+	free(ret->requestId);
+	free(ret->invalidUrls);
+	free(ret->invalidDirs);
+}
+
+QINIU_DLLAPI void Qiniu_Free_CdnPrefetchRet(Qiniu_Cdn_PrefetchRet* ret)
+{
+	free(ret->error);
+	free(ret->requestId);
+	free(ret->invalidUrls);
+}
+
+QINIU_DLLAPI void Qiniu_Free_CdnFluxRet(Qiniu_Cdn_FluxRet* ret)
+{
+	if (ret->error != NULL) {
+		free(ret->error);
+	}
+
+	if (ret->data_a != NULL) {
+		for (int i = 0; i < ret->num; ++i) {
+			if (ret->data_a[i].hasValue != NULL) {
+				free(ret->data_a[i].domain);
+				for (int j = 0; j < ret->data_a[i].count; ++j) {
+					free(ret->data_a[i].item_a[j].time);
+				}
+				free(ret->data_a[i].item_a);
+			}
+		}
+		free(ret->data_a);
+	}
+}
+
+QINIU_DLLAPI void Qiniu_Free_CdnBandwidthRet(Qiniu_Cdn_BandwidthRet* ret)
+{
+	if (ret->error != NULL) {
+		free(ret->error);
+	}
+
+	if (ret->data_a != NULL) {
+		for (int i = 0; i < ret->num; ++i) {
+			if (ret->data_a[i].hasValue != NULL) {
+				free(ret->data_a[i].domain);
+				for (int j = 0; j < ret->data_a[i].count; ++j) {
+					free(ret->data_a[i].item_a[j].time);
+				}
+				free(ret->data_a[i].item_a);
+			}
+		}
+		free(ret->data_a);
+	}
+}
+
+QINIU_DLLAPI void Qiniu_Free_CdnLogListRet(Qiniu_Cdn_LogListRet* ret)
+{
+	if (ret->error != NULL) {
+		free(ret->error);
+	}
+
+	if (ret->data_a != NULL) {
+		for (int i = 0; i < ret->num; ++i) {
+			if (ret->data_a[i].hasValue != FALSE) {
+				free(ret->data_a[i].domain);
+				for (int j = 0; j < ret->data_a[i].count; ++j) {
+					free(ret->data_a[i].item_a[j].name);
+					free(ret->data_a[i].item_a[j].url);
+				}
+				free(ret->data_a[i].item_a);
+			}
+		}
+		free(ret->data_a);
+	}
 }

--- a/qiniu/cdn.c
+++ b/qiniu/cdn.c
@@ -1,0 +1,416 @@
+#include <openssl/md5.h>
+#include <ctype.h>
+#include "base.h"
+#include "cdn.h"
+#include "../cJSON/cJSON.h"
+
+static const char Qiniu_Cdn_HexadecimalMap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+typedef int (*Qiniu_Cdn_NeedToPercentEncode_Fn)(int c);
+
+static int Qiniu_Cdn_NeedToPercentEncode(int c)
+{
+    if ('a' <= c) {
+        if (c <= 'z' || c == '~') {
+            return 0;
+        }
+        // { | } DEL or chars > 127
+        return 1;
+    } // if
+
+    if (c <= '9') {
+        if ('0' <= c || c == '.' || c == '-') {
+            return 0;
+        } // if
+        return 1;
+    } // if
+
+    if ('A' <= c) {
+        if (c <= 'Z' || c == '_') {
+            return 0;
+        }
+    } // if
+    return 1;
+}
+
+static size_t Qiniu_Cdn_PercentEncode(char * buf, size_t buf_size, const char * bin, size_t bin_size, Qiniu_Cdn_NeedToPercentEncode_Fn needToPercentEncode)
+{
+    int i = 0;
+    int m = 0;
+    int ret = 0;
+
+    if (! needToPercentEncode) needToPercentEncode = &Qiniu_Cdn_NeedToPercentEncode;
+
+    if (!buf || buf_size <= 0) {
+        for (i = 0; i < bin_size; i += 1) {
+            if (needToPercentEncode(bin[i])) {
+                if (bin[i] == '%' && (i + 2 < bin_size) && isxdigit(bin[i+1]) && isxdigit(bin[i+2])) {
+                    ret += 1;
+                } else {
+                    ret += 3;
+                } // if
+            } else {
+                ret += 1;
+            } // if
+        } // for
+        return ret;
+    } else if (buf_size < bin_size) {
+        return -1;
+    } // if
+
+    for (i = 0; i < bin_size; i += 1) {
+        if (needToPercentEncode(bin[i])) {
+            if (bin[i] == '%' && (i + 2 < bin_size) && isxdigit(bin[i+1]) && isxdigit(bin[i+2])) {
+                    if (m + 1 > buf_size) return -1;
+                    buf[m++] = bin[i];
+            } else {
+                if (m + 3 > buf_size) return -1;
+                buf[m++] = '%';
+                buf[m++] = Qiniu_Cdn_HexadecimalMap[(bin[i] >> 4) & 0xF];
+                buf[m++] = Qiniu_Cdn_HexadecimalMap[bin[i] & 0xF];
+            } // if
+        } else {
+            if (m + 1 > buf_size) return -1;
+            buf[m++] = bin[i];
+        }
+    } // for
+    return m;
+}
+
+typedef union _Qiniu_Cdn_UnixTime
+{
+    Qiniu_Uint64 tm;
+    char bytes[4]; // Only for little-endian architectures.
+} Qiniu_Cdn_UnixTime;
+
+static int Qiniu_Cdn_NeedToPercentEncodeWithoutSlash(int c)
+{
+    if (c == '/') return 0;
+    return Qiniu_Cdn_NeedToPercentEncode(c);
+}
+
+QINIU_DLLAPI char * Qiniu_Cdn_MakeDownloadUrlWithDeadline(const char * key, const char * url, Qiniu_Uint64 deadline)
+{
+    int i;
+    char * pos;
+    char * path;
+    size_t pathSize;
+    char * encodedPath;
+    size_t encodedPathSize;
+    char * authedUrl;
+    size_t authedUrlSize;
+    size_t baseUrlSize;
+    char * signStr;
+    char * query;
+    unsigned char sign[MD5_DIGEST_LENGTH];
+    char encodedSign[MD5_DIGEST_LENGTH * 2 + 1];
+    char encodedUnixTime[sizeof(Qiniu_Cdn_UnixTime) * 2 + 1];
+    Qiniu_Cdn_UnixTime ut;
+    MD5_CTX md5Ctx;
+
+    ut.tm = deadline;
+    encodedUnixTime[0] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[3] >> 4) & 0xF]);
+    encodedUnixTime[1] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[3] & 0xF]);
+    encodedUnixTime[2] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[2] >> 4) & 0xF]);
+    encodedUnixTime[3] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[2] & 0xF]);
+    encodedUnixTime[4] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[1] >> 4) & 0xF]);
+    encodedUnixTime[5] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[1] & 0xF]);
+    encodedUnixTime[6] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[0] >> 4) & 0xF]);
+    encodedUnixTime[7] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[0] & 0xF]);
+    encodedUnixTime[8] = '\0';
+
+    pos = strstr(url, "://"); 
+    if (! pos) return NULL;
+    path = strchr(pos + 3, '/');
+    if (! path) return NULL;
+
+    query = strchr(path, '?');
+    if (query) {
+        pathSize = query - path;
+    } else {
+        pathSize = strlen(url) - (path - url);
+    } // if
+
+    encodedPathSize = Qiniu_Cdn_PercentEncode(NULL, -1, path, pathSize, &Qiniu_Cdn_NeedToPercentEncodeWithoutSlash);
+    encodedPath = malloc(encodedPathSize + 1);
+    if (! encodedPath) return NULL;
+
+    Qiniu_Cdn_PercentEncode(encodedPath, encodedPathSize, path, pathSize, &Qiniu_Cdn_NeedToPercentEncodeWithoutSlash);
+
+    signStr = Qiniu_String_Concat3(key, encodedPath, encodedUnixTime);
+    if (! signStr) {
+        free(encodedPath);
+        return NULL;
+    } // if
+
+    MD5_Init(&md5Ctx);
+    MD5_Update(&md5Ctx, signStr, strlen(signStr));
+    MD5_Final((unsigned char *)sign, &md5Ctx);
+    Qiniu_Free(signStr);
+
+    for (i = 0; i < MD5_DIGEST_LENGTH; i += 1) {
+        encodedSign[i * 2] = tolower(Qiniu_Cdn_HexadecimalMap[(sign[i] >> 4) & 0xF]);
+        encodedSign[i * 2 + 1] = tolower(Qiniu_Cdn_HexadecimalMap[sign[i] & 0xF]);
+    } // if
+    encodedSign[MD5_DIGEST_LENGTH * 2] = '\0';
+    
+    baseUrlSize = path - url;
+
+    authedUrlSize = baseUrlSize + encodedPathSize + 6 + (sizeof(encodedSign) - 1) + 3 + (sizeof(encodedUnixTime) - 1) + 1;
+    authedUrl = malloc(authedUrlSize);
+    if (! authedUrl) {
+        free(encodedPath);
+        return NULL;
+    } // if
+
+    memcpy(authedUrl, url, baseUrlSize);
+    if (query) {
+        Qiniu_snprintf(authedUrl + baseUrlSize, authedUrlSize - baseUrlSize, "%s%s&sign=%s&t=%s", encodedPath, query, encodedSign, encodedUnixTime);
+    } else {
+        Qiniu_snprintf(authedUrl + baseUrlSize, authedUrlSize - baseUrlSize, "%s?sign=%s&t=%s", encodedPath, encodedSign, encodedUnixTime);
+    } // if
+
+    free(encodedPath);
+    return authedUrl;
+}
+
+// TODO: Parse `ret->invalidUrls` and `ret->invalidDirs` fields
+QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshUrls(Qiniu_Client*self, Qiniu_Cdn_RefreshRet* ret, const char* urls[], const int num)
+{  
+    Qiniu_Error err;
+
+    char* path = "/v2/tune/refresh";
+    char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+
+    cJSON* root = cJSON_CreateObject();
+    cJSON* url_a = cJSON_CreateStringArray(urls,num);    
+    cJSON_AddItemToObject(root,"urls",url_a);
+    //cJSON_AddItemToObject(root,"dirs",cJSON_CreateStringArray(NULL,0));
+    char* body = cJSON_PrintUnformatted(root);
+
+    Qiniu_Json* jsonRet = NULL;   
+    
+    err = Qiniu_Client_CallWithBuffer2(
+        self,&jsonRet,url,body,strlen(body),"application/json");
+    
+    if (err.code == 200) {
+		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+        ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+        ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
+        //ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
+        //ret->invalidDirs = Qiniu_Json_GetObjectItem(jsonRet, "invalidDirs", "");
+        ret->urlQuotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
+        ret->urlSurplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
+        ret->dirQuotaDay = Qiniu_Json_GetInt(jsonRet, "dirQuotaDay", 0);
+        ret->dirSurplusDay = Qiniu_Json_GetInt(jsonRet, "dirSurplusDay", 0);
+	}
+
+    Qiniu_Free(url);
+    Qiniu_Free(body);
+    cJSON_Delete(root);
+
+    return err;
+}
+
+// TODO: Parse `ret->invalidUrls` and `ret->invalidDirs` fields
+QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshDirs(Qiniu_Client*self, Qiniu_Cdn_RefreshRet* ret, const char* dirs[], const int num)
+{  
+    Qiniu_Error err;
+
+    char* path = "/v2/tune/refresh";
+    char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+
+    cJSON* root = cJSON_CreateObject();
+    cJSON* dir_a = cJSON_CreateStringArray(dirs,num);
+    //cJSON_AddItemToObject(root,"urls",cJSON_CreateStringArray(NULL,0));
+    cJSON_AddItemToObject(root,"dirs",dir_a); 
+    char* body = cJSON_PrintUnformatted(root);
+
+    Qiniu_Json* jsonRet = NULL;   
+
+    err = Qiniu_Client_CallWithBuffer2(
+        self, &jsonRet,url,body,strlen(body),"application/json");
+    
+    if (err.code == 200) {
+		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+        ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+        ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
+        //ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
+        //ret->invalidDirs = Qiniu_Json_GetObjectItem(jsonRet, "invalidDirs", "");
+        ret->urlQuotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
+        ret->urlSurplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
+        ret->dirQuotaDay = Qiniu_Json_GetInt(jsonRet, "dirQuotaDay", 0);
+        ret->dirSurplusDay = Qiniu_Json_GetInt(jsonRet, "dirSurplusDay", 0);        
+	}
+
+    Qiniu_Free(url);
+    Qiniu_Free(body);
+    cJSON_Delete(root);
+
+    return err;
+}
+
+// TODO: Parse `ret->invalidUrls` field
+QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_PrefetchUrls(Qiniu_Client*self, Qiniu_Cdn_PrefetchRet* ret, const char* urls[], const int num)
+{  
+    Qiniu_Error err;
+
+    char* path = "/v2/tune/prefetch";
+    char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+
+    cJSON* root = cJSON_CreateObject();
+    cJSON* url_a = cJSON_CreateStringArray(urls,num);
+    cJSON_AddItemToObject(root,"urls",url_a);   
+    char* body = cJSON_PrintUnformatted(root);
+
+    Qiniu_Json* jsonRet = NULL;   
+
+    err = Qiniu_Client_CallWithBuffer2(
+        self,&jsonRet,url,body,strlen(body),"application/json");
+
+    
+    if (err.code == 200) {
+		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+        ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+        ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
+        //ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
+        ret->quotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
+        ret->surplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
+	}
+
+    Qiniu_Free(url);
+    Qiniu_Free(body);
+    cJSON_Delete(root);
+
+    return err;
+}
+
+// TODO: Parse `ret->time` and `ret->data` fields
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetFluxData(
+    Qiniu_Client* self, 
+    Qiniu_Cdn_FluxBandwidthRet* ret,
+    const char* startDate,
+    const char* endDate,
+    const char* granularity,
+    const char* domains[], 
+    const int num)
+ {
+     Qiniu_Error err;
+
+     char* path = "/v2/tune/flux";
+     char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+
+     char* domains_str = Qiniu_String_Join(";",domains,num);
+
+     cJSON* root = cJSON_CreateObject();
+     cJSON_AddStringToObject(root,"startDate",startDate);   
+     cJSON_AddStringToObject(root,"endDate",endDate);
+     cJSON_AddStringToObject(root,"granularity",granularity);    
+     cJSON_AddStringToObject(root,"domains",domains_str);
+     char* body = cJSON_PrintUnformatted(root);
+
+     Qiniu_Json* jsonRet = NULL;   
+
+     err = Qiniu_Client_CallWithBuffer2(
+         self,&jsonRet,url,body,strlen(body),"application/json");
+
+    
+     if (err.code == 200) {
+		 ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+         ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+         //ret->time = Qiniu_Json_GetString(jsonRet, "time", "");
+         //ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+	 }
+
+     Qiniu_Free(url);
+     //Qiniu_Free(domains_str);
+     Qiniu_Free(body);
+     cJSON_Delete(root);
+
+     return err;
+ }
+
+// TODO: Parse `ret->time` and `ret->data` fields
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetBandwidthData(
+    Qiniu_Client* self,
+    Qiniu_Cdn_FluxBandwidthRet* ret, 
+    const char* startDate,
+    const char* endDate,
+    const char* granularity,
+    const char* domains[],
+    const int num)
+{
+     Qiniu_Error err;
+
+     char* path = "/v2/tune/bandwidth";
+     char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+
+     char* domains_str = Qiniu_String_Join(";",domains,num);
+
+     cJSON* root = cJSON_CreateObject();
+     cJSON_AddStringToObject(root,"startDate",startDate);   
+     cJSON_AddStringToObject(root,"endDate",endDate);
+     cJSON_AddStringToObject(root,"granularity",granularity);    
+     cJSON_AddStringToObject(root,"domains",domains_str);
+     char* body = cJSON_PrintUnformatted(root);
+
+     Qiniu_Json* jsonRet = NULL;   
+
+     err = Qiniu_Client_CallWithBuffer2(
+         self,&jsonRet,url,body,strlen(body),"application/json");
+
+    
+     if (err.code == 200) {
+		 ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+         ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+         //ret->time = Qiniu_Json_GetString(jsonRet, "time", "");
+         //ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+	 }
+
+     Qiniu_Free(url);
+     Qiniu_Free(domains_str);
+     Qiniu_Free(body);
+     cJSON_Delete(root);
+
+     return err;
+}
+
+// TODO: Parse `ret->data` field
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetLogList(
+    Qiniu_Client* self,
+    Qiniu_Cdn_LogListRet* ret,
+    const char* day,
+    const char* domains[],
+    const int num)
+{
+     Qiniu_Error err;
+
+     char* path = "/v2/tune/log/list";
+     char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+
+     char* domains_str = Qiniu_String_Join(";",domains,num);
+
+     cJSON* root = cJSON_CreateObject();
+     cJSON_AddStringToObject(root,"day",day);      
+     cJSON_AddStringToObject(root,"domains",domains_str);
+     char* body = cJSON_PrintUnformatted(root);
+
+     Qiniu_Json* jsonRet = NULL;   
+
+     err = Qiniu_Client_CallWithBuffer2(
+         self,&jsonRet,url,body,strlen(body),"application/json");
+
+    
+     if (err.code == 200) {
+		 ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+         ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+         //ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+	 }
+
+     Qiniu_Free(url);
+     Qiniu_Free(domains_str);
+     Qiniu_Free(body);
+     cJSON_Delete(root);
+
+     return err;
+}

--- a/qiniu/cdn.c
+++ b/qiniu/cdn.c
@@ -4,413 +4,420 @@
 #include "cdn.h"
 #include "../cJSON/cJSON.h"
 
-static const char Qiniu_Cdn_HexadecimalMap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+static const char Qiniu_Cdn_HexadecimalMap[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
 
-typedef int (*Qiniu_Cdn_NeedToPercentEncode_Fn)(int c);
+typedef int(*Qiniu_Cdn_NeedToPercentEncode_Fn)(int c);
 
 static int Qiniu_Cdn_NeedToPercentEncode(int c)
 {
-    if ('a' <= c) {
-        if (c <= 'z' || c == '~') {
-            return 0;
-        }
-        // { | } DEL or chars > 127
-        return 1;
-    } // if
+	if ('a' <= c) {
+		if (c <= 'z' || c == '~') {
+			return 0;
+		}
+		// { | } DEL or chars > 127
+		return 1;
+	} // if
 
-    if (c <= '9') {
-        if ('0' <= c || c == '.' || c == '-') {
-            return 0;
-        } // if
-        return 1;
-    } // if
+	if (c <= '9') {
+		if ('0' <= c || c == '.' || c == '-') {
+			return 0;
+		} // if
+		return 1;
+	} // if
 
-    if ('A' <= c) {
-        if (c <= 'Z' || c == '_') {
-            return 0;
-        }
-    } // if
-    return 1;
+	if ('A' <= c) {
+		if (c <= 'Z' || c == '_') {
+			return 0;
+		}
+	} // if
+	return 1;
 }
 
 static size_t Qiniu_Cdn_PercentEncode(char * buf, size_t buf_size, const char * bin, size_t bin_size, Qiniu_Cdn_NeedToPercentEncode_Fn needToPercentEncode)
 {
-    int i = 0;
-    int m = 0;
-    int ret = 0;
+	int i = 0;
+	int m = 0;
+	int ret = 0;
 
-    if (! needToPercentEncode) needToPercentEncode = &Qiniu_Cdn_NeedToPercentEncode;
+	if (!needToPercentEncode) needToPercentEncode = &Qiniu_Cdn_NeedToPercentEncode;
 
-    if (!buf || buf_size <= 0) {
-        for (i = 0; i < bin_size; i += 1) {
-            if (needToPercentEncode(bin[i])) {
-                if (bin[i] == '%' && (i + 2 < bin_size) && isxdigit(bin[i+1]) && isxdigit(bin[i+2])) {
-                    ret += 1;
-                } else {
-                    ret += 3;
-                } // if
-            } else {
-                ret += 1;
-            } // if
-        } // for
-        return ret;
-    } else if (buf_size < bin_size) {
-        return -1;
-    } // if
+	if (!buf || buf_size <= 0) {
+		for (i = 0; i < bin_size; i += 1) {
+			if (needToPercentEncode(bin[i])) {
+				if (bin[i] == '%' && (i + 2 < bin_size) && isxdigit(bin[i + 1]) && isxdigit(bin[i + 2])) {
+					ret += 1;
+				}
+				else {
+					ret += 3;
+				} // if
+			}
+			else {
+				ret += 1;
+			} // if
+		} // for
+		return ret;
+	}
+	else if (buf_size < bin_size) {
+		return -1;
+	} // if
 
-    for (i = 0; i < bin_size; i += 1) {
-        if (needToPercentEncode(bin[i])) {
-            if (bin[i] == '%' && (i + 2 < bin_size) && isxdigit(bin[i+1]) && isxdigit(bin[i+2])) {
-                    if (m + 1 > buf_size) return -1;
-                    buf[m++] = bin[i];
-            } else {
-                if (m + 3 > buf_size) return -1;
-                buf[m++] = '%';
-                buf[m++] = Qiniu_Cdn_HexadecimalMap[(bin[i] >> 4) & 0xF];
-                buf[m++] = Qiniu_Cdn_HexadecimalMap[bin[i] & 0xF];
-            } // if
-        } else {
-            if (m + 1 > buf_size) return -1;
-            buf[m++] = bin[i];
-        }
-    } // for
-    return m;
+	for (i = 0; i < bin_size; i += 1) {
+		if (needToPercentEncode(bin[i])) {
+			if (bin[i] == '%' && (i + 2 < bin_size) && isxdigit(bin[i + 1]) && isxdigit(bin[i + 2])) {
+				if (m + 1 > buf_size) return -1;
+				buf[m++] = bin[i];
+			}
+			else {
+				if (m + 3 > buf_size) return -1;
+				buf[m++] = '%';
+				buf[m++] = Qiniu_Cdn_HexadecimalMap[(bin[i] >> 4) & 0xF];
+				buf[m++] = Qiniu_Cdn_HexadecimalMap[bin[i] & 0xF];
+			} // if
+		}
+		else {
+			if (m + 1 > buf_size) return -1;
+			buf[m++] = bin[i];
+		}
+	} // for
+	return m;
 }
 
 typedef union _Qiniu_Cdn_UnixTime
 {
-    Qiniu_Uint64 tm;
-    char bytes[4]; // Only for little-endian architectures.
+	Qiniu_Uint64 tm;
+	char bytes[4]; // Only for little-endian architectures.
 } Qiniu_Cdn_UnixTime;
 
 static int Qiniu_Cdn_NeedToPercentEncodeWithoutSlash(int c)
 {
-    if (c == '/') return 0;
-    return Qiniu_Cdn_NeedToPercentEncode(c);
+	if (c == '/') return 0;
+	return Qiniu_Cdn_NeedToPercentEncode(c);
 }
 
 QINIU_DLLAPI char * Qiniu_Cdn_MakeDownloadUrlWithDeadline(const char * key, const char * url, Qiniu_Uint64 deadline)
 {
-    int i;
-    char * pos;
-    char * path;
-    size_t pathSize;
-    char * encodedPath;
-    size_t encodedPathSize;
-    char * authedUrl;
-    size_t authedUrlSize;
-    size_t baseUrlSize;
-    char * signStr;
-    char * query;
-    unsigned char sign[MD5_DIGEST_LENGTH];
-    char encodedSign[MD5_DIGEST_LENGTH * 2 + 1];
-    char encodedUnixTime[sizeof(Qiniu_Cdn_UnixTime) * 2 + 1];
-    Qiniu_Cdn_UnixTime ut;
-    MD5_CTX md5Ctx;
+	int i;
+	char * pos;
+	char * path;
+	size_t pathSize;
+	char * encodedPath;
+	size_t encodedPathSize;
+	char * authedUrl;
+	size_t authedUrlSize;
+	size_t baseUrlSize;
+	char * signStr;
+	char * query;
+	unsigned char sign[MD5_DIGEST_LENGTH];
+	char encodedSign[MD5_DIGEST_LENGTH * 2 + 1];
+	char encodedUnixTime[sizeof(Qiniu_Cdn_UnixTime) * 2 + 1];
+	Qiniu_Cdn_UnixTime ut;
+	MD5_CTX md5Ctx;
 
-    ut.tm = deadline;
-    encodedUnixTime[0] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[3] >> 4) & 0xF]);
-    encodedUnixTime[1] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[3] & 0xF]);
-    encodedUnixTime[2] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[2] >> 4) & 0xF]);
-    encodedUnixTime[3] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[2] & 0xF]);
-    encodedUnixTime[4] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[1] >> 4) & 0xF]);
-    encodedUnixTime[5] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[1] & 0xF]);
-    encodedUnixTime[6] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[0] >> 4) & 0xF]);
-    encodedUnixTime[7] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[0] & 0xF]);
-    encodedUnixTime[8] = '\0';
+	ut.tm = deadline;
+	encodedUnixTime[0] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[3] >> 4) & 0xF]);
+	encodedUnixTime[1] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[3] & 0xF]);
+	encodedUnixTime[2] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[2] >> 4) & 0xF]);
+	encodedUnixTime[3] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[2] & 0xF]);
+	encodedUnixTime[4] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[1] >> 4) & 0xF]);
+	encodedUnixTime[5] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[1] & 0xF]);
+	encodedUnixTime[6] = tolower(Qiniu_Cdn_HexadecimalMap[(ut.bytes[0] >> 4) & 0xF]);
+	encodedUnixTime[7] = tolower(Qiniu_Cdn_HexadecimalMap[ut.bytes[0] & 0xF]);
+	encodedUnixTime[8] = '\0';
 
-    pos = strstr(url, "://"); 
-    if (! pos) return NULL;
-    path = strchr(pos + 3, '/');
-    if (! path) return NULL;
+	pos = strstr(url, "://");
+	if (!pos) return NULL;
+	path = strchr(pos + 3, '/');
+	if (!path) return NULL;
 
-    query = strchr(path, '?');
-    if (query) {
-        pathSize = query - path;
-    } else {
-        pathSize = strlen(url) - (path - url);
-    } // if
+	query = strchr(path, '?');
+	if (query) {
+		pathSize = query - path;
+	}
+	else {
+		pathSize = strlen(url) - (path - url);
+	} // if
 
-    encodedPathSize = Qiniu_Cdn_PercentEncode(NULL, -1, path, pathSize, &Qiniu_Cdn_NeedToPercentEncodeWithoutSlash);
-    encodedPath = malloc(encodedPathSize + 1);
-    if (! encodedPath) return NULL;
+	encodedPathSize = Qiniu_Cdn_PercentEncode(NULL, -1, path, pathSize, &Qiniu_Cdn_NeedToPercentEncodeWithoutSlash);
+	encodedPath = malloc(encodedPathSize + 1);
+	if (!encodedPath) return NULL;
 
-    Qiniu_Cdn_PercentEncode(encodedPath, encodedPathSize, path, pathSize, &Qiniu_Cdn_NeedToPercentEncodeWithoutSlash);
+	Qiniu_Cdn_PercentEncode(encodedPath, encodedPathSize, path, pathSize, &Qiniu_Cdn_NeedToPercentEncodeWithoutSlash);
 
-    signStr = Qiniu_String_Concat3(key, encodedPath, encodedUnixTime);
-    if (! signStr) {
-        free(encodedPath);
-        return NULL;
-    } // if
+	signStr = Qiniu_String_Concat3(key, encodedPath, encodedUnixTime);
+	if (!signStr) {
+		free(encodedPath);
+		return NULL;
+	} // if
 
-    MD5_Init(&md5Ctx);
-    MD5_Update(&md5Ctx, signStr, strlen(signStr));
-    MD5_Final((unsigned char *)sign, &md5Ctx);
-    Qiniu_Free(signStr);
+	MD5_Init(&md5Ctx);
+	MD5_Update(&md5Ctx, signStr, strlen(signStr));
+	MD5_Final((unsigned char *)sign, &md5Ctx);
+	Qiniu_Free(signStr);
 
-    for (i = 0; i < MD5_DIGEST_LENGTH; i += 1) {
-        encodedSign[i * 2] = tolower(Qiniu_Cdn_HexadecimalMap[(sign[i] >> 4) & 0xF]);
-        encodedSign[i * 2 + 1] = tolower(Qiniu_Cdn_HexadecimalMap[sign[i] & 0xF]);
-    } // if
-    encodedSign[MD5_DIGEST_LENGTH * 2] = '\0';
-    
-    baseUrlSize = path - url;
+	for (i = 0; i < MD5_DIGEST_LENGTH; i += 1) {
+		encodedSign[i * 2] = tolower(Qiniu_Cdn_HexadecimalMap[(sign[i] >> 4) & 0xF]);
+		encodedSign[i * 2 + 1] = tolower(Qiniu_Cdn_HexadecimalMap[sign[i] & 0xF]);
+	} // if
+	encodedSign[MD5_DIGEST_LENGTH * 2] = '\0';
 
-    authedUrlSize = baseUrlSize + encodedPathSize + 6 + (sizeof(encodedSign) - 1) + 3 + (sizeof(encodedUnixTime) - 1) + 1;
-    authedUrl = malloc(authedUrlSize);
-    if (! authedUrl) {
-        free(encodedPath);
-        return NULL;
-    } // if
+	baseUrlSize = path - url;
 
-    memcpy(authedUrl, url, baseUrlSize);
-    if (query) {
-        Qiniu_snprintf(authedUrl + baseUrlSize, authedUrlSize - baseUrlSize, "%s%s&sign=%s&t=%s", encodedPath, query, encodedSign, encodedUnixTime);
-    } else {
-        Qiniu_snprintf(authedUrl + baseUrlSize, authedUrlSize - baseUrlSize, "%s?sign=%s&t=%s", encodedPath, encodedSign, encodedUnixTime);
-    } // if
+	authedUrlSize = baseUrlSize + encodedPathSize + 6 + (sizeof(encodedSign) - 1) + 3 + (sizeof(encodedUnixTime) - 1) + 1;
+	authedUrl = malloc(authedUrlSize);
+	if (!authedUrl) {
+		free(encodedPath);
+		return NULL;
+	} // if
 
-    free(encodedPath);
-    return authedUrl;
+	memcpy(authedUrl, url, baseUrlSize);
+	if (query) {
+		Qiniu_snprintf(authedUrl + baseUrlSize, authedUrlSize - baseUrlSize, "%s%s&sign=%s&t=%s", encodedPath, query, encodedSign, encodedUnixTime);
+	}
+	else {
+		Qiniu_snprintf(authedUrl + baseUrlSize, authedUrlSize - baseUrlSize, "%s?sign=%s&t=%s", encodedPath, encodedSign, encodedUnixTime);
+	} // if
+
+	free(encodedPath);
+	return authedUrl;
 }
 
 // TODO: Parse `ret->invalidUrls` and `ret->invalidDirs` fields
 QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshUrls(Qiniu_Client*self, Qiniu_Cdn_RefreshRet* ret, const char* urls[], const int num)
-{  
-    Qiniu_Error err;
+{
+	Qiniu_Error err;
 
-    char* path = "/v2/tune/refresh";
-    char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+	char* path = "/v2/tune/refresh";
+	char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
 
-    cJSON* root = cJSON_CreateObject();
-    cJSON* url_a = cJSON_CreateStringArray(urls,num);    
-    cJSON_AddItemToObject(root,"urls",url_a);
-    //cJSON_AddItemToObject(root,"dirs",cJSON_CreateStringArray(NULL,0));
-    char* body = cJSON_PrintUnformatted(root);
+	cJSON* root = cJSON_CreateObject();
+	cJSON* url_a = cJSON_CreateStringArray(urls, num);
+	cJSON_AddItemToObject(root, "urls", url_a);
+	//cJSON_AddItemToObject(root,"dirs",cJSON_CreateStringArray(NULL,0));
+	char* body = cJSON_PrintUnformatted(root);
 
-    Qiniu_Json* jsonRet = NULL;   
-    
-    err = Qiniu_Client_CallWithBuffer2(
-        self,&jsonRet,url,body,strlen(body),"application/json");
-    
-    if (err.code == 200) {
+	Qiniu_Json* jsonRet = NULL;
+
+	err = Qiniu_Client_CallWithBuffer2(
+		self, &jsonRet, url, body, strlen(body), "application/json");
+
+	if (err.code == 200) {
 		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-        ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-        ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
-        //ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
-        //ret->invalidDirs = Qiniu_Json_GetObjectItem(jsonRet, "invalidDirs", "");
-        ret->urlQuotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
-        ret->urlSurplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
-        ret->dirQuotaDay = Qiniu_Json_GetInt(jsonRet, "dirQuotaDay", 0);
-        ret->dirSurplusDay = Qiniu_Json_GetInt(jsonRet, "dirSurplusDay", 0);
+		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+		ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
+		//ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
+		//ret->invalidDirs = Qiniu_Json_GetObjectItem(jsonRet, "invalidDirs", "");
+		ret->urlQuotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
+		ret->urlSurplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
+		ret->dirQuotaDay = Qiniu_Json_GetInt(jsonRet, "dirQuotaDay", 0);
+		ret->dirSurplusDay = Qiniu_Json_GetInt(jsonRet, "dirSurplusDay", 0);
 	}
 
-    Qiniu_Free(url);
-    Qiniu_Free(body);
-    cJSON_Delete(root);
+	Qiniu_Free(url);
+	Qiniu_Free(body);
+	cJSON_Delete(root);
 
-    return err;
+	return err;
 }
 
 // TODO: Parse `ret->invalidUrls` and `ret->invalidDirs` fields
 QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_RefreshDirs(Qiniu_Client*self, Qiniu_Cdn_RefreshRet* ret, const char* dirs[], const int num)
-{  
-    Qiniu_Error err;
+{
+	Qiniu_Error err;
 
-    char* path = "/v2/tune/refresh";
-    char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+	char* path = "/v2/tune/refresh";
+	char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
 
-    cJSON* root = cJSON_CreateObject();
-    cJSON* dir_a = cJSON_CreateStringArray(dirs,num);
-    //cJSON_AddItemToObject(root,"urls",cJSON_CreateStringArray(NULL,0));
-    cJSON_AddItemToObject(root,"dirs",dir_a); 
-    char* body = cJSON_PrintUnformatted(root);
+	cJSON* root = cJSON_CreateObject();
+	cJSON* dir_a = cJSON_CreateStringArray(dirs, num);
+	//cJSON_AddItemToObject(root,"urls",cJSON_CreateStringArray(NULL,0));
+	cJSON_AddItemToObject(root, "dirs", dir_a);
+	char* body = cJSON_PrintUnformatted(root);
 
-    Qiniu_Json* jsonRet = NULL;   
+	Qiniu_Json* jsonRet = NULL;
 
-    err = Qiniu_Client_CallWithBuffer2(
-        self, &jsonRet,url,body,strlen(body),"application/json");
-    
-    if (err.code == 200) {
+	err = Qiniu_Client_CallWithBuffer2(
+		self, &jsonRet, url, body, strlen(body), "application/json");
+
+	if (err.code == 200) {
 		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-        ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-        ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
-        //ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
-        //ret->invalidDirs = Qiniu_Json_GetObjectItem(jsonRet, "invalidDirs", "");
-        ret->urlQuotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
-        ret->urlSurplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
-        ret->dirQuotaDay = Qiniu_Json_GetInt(jsonRet, "dirQuotaDay", 0);
-        ret->dirSurplusDay = Qiniu_Json_GetInt(jsonRet, "dirSurplusDay", 0);        
+		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+		ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
+		//ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
+		//ret->invalidDirs = Qiniu_Json_GetObjectItem(jsonRet, "invalidDirs", "");
+		ret->urlQuotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
+		ret->urlSurplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
+		ret->dirQuotaDay = Qiniu_Json_GetInt(jsonRet, "dirQuotaDay", 0);
+		ret->dirSurplusDay = Qiniu_Json_GetInt(jsonRet, "dirSurplusDay", 0);
 	}
 
-    Qiniu_Free(url);
-    Qiniu_Free(body);
-    cJSON_Delete(root);
+	Qiniu_Free(url);
+	Qiniu_Free(body);
+	cJSON_Delete(root);
 
-    return err;
+	return err;
 }
 
 // TODO: Parse `ret->invalidUrls` field
 QINIU_DLLAPI Qiniu_Error Qiniu_Cdn_PrefetchUrls(Qiniu_Client*self, Qiniu_Cdn_PrefetchRet* ret, const char* urls[], const int num)
-{  
-    Qiniu_Error err;
+{
+	Qiniu_Error err;
 
-    char* path = "/v2/tune/prefetch";
-    char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+	char* path = "/v2/tune/prefetch";
+	char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
 
-    cJSON* root = cJSON_CreateObject();
-    cJSON* url_a = cJSON_CreateStringArray(urls,num);
-    cJSON_AddItemToObject(root,"urls",url_a);   
-    char* body = cJSON_PrintUnformatted(root);
+	cJSON* root = cJSON_CreateObject();
+	cJSON* url_a = cJSON_CreateStringArray(urls, num);
+	cJSON_AddItemToObject(root, "urls", url_a);
+	char* body = cJSON_PrintUnformatted(root);
 
-    Qiniu_Json* jsonRet = NULL;   
+	Qiniu_Json* jsonRet = NULL;
 
-    err = Qiniu_Client_CallWithBuffer2(
-        self,&jsonRet,url,body,strlen(body),"application/json");
+	err = Qiniu_Client_CallWithBuffer2(
+		self, &jsonRet, url, body, strlen(body), "application/json");
 
-    
-    if (err.code == 200) {
+
+	if (err.code == 200) {
 		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-        ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-        ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
-        //ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
-        ret->quotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
-        ret->surplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
+		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+		ret->requestId = Qiniu_Json_GetString(jsonRet, "requestId", "");
+		//ret->invalidUrls = Qiniu_Json_GetObjectItem(jsonRet, "invalidUrls", "");
+		ret->quotaDay = Qiniu_Json_GetInt(jsonRet, "urlQuotaDay", 0);
+		ret->surplusDay = Qiniu_Json_GetInt(jsonRet, "urlSurplusDay", 0);
 	}
 
-    Qiniu_Free(url);
-    Qiniu_Free(body);
-    cJSON_Delete(root);
+	Qiniu_Free(url);
+	Qiniu_Free(body);
+	cJSON_Delete(root);
 
-    return err;
+	return err;
 }
 
 // TODO: Parse `ret->time` and `ret->data` fields
 QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetFluxData(
-    Qiniu_Client* self, 
-    Qiniu_Cdn_FluxBandwidthRet* ret,
-    const char* startDate,
-    const char* endDate,
-    const char* granularity,
-    const char* domains[], 
-    const int num)
- {
-     Qiniu_Error err;
+	Qiniu_Client* self,
+	Qiniu_Cdn_FluxBandwidthRet* ret,
+	const char* startDate,
+	const char* endDate,
+	const char* granularity,
+	const char* domains[],
+	const int num)
+{
+	Qiniu_Error err;
 
-     char* path = "/v2/tune/flux";
-     char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+	char* path = "/v2/tune/flux";
+	char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
 
-     char* domains_str = Qiniu_String_Join(";",domains,num);
+	char* domains_str = Qiniu_String_Join(";", domains, num);
 
-     cJSON* root = cJSON_CreateObject();
-     cJSON_AddStringToObject(root,"startDate",startDate);   
-     cJSON_AddStringToObject(root,"endDate",endDate);
-     cJSON_AddStringToObject(root,"granularity",granularity);    
-     cJSON_AddStringToObject(root,"domains",domains_str);
-     char* body = cJSON_PrintUnformatted(root);
+	cJSON* root = cJSON_CreateObject();
+	cJSON_AddStringToObject(root, "startDate", startDate);
+	cJSON_AddStringToObject(root, "endDate", endDate);
+	cJSON_AddStringToObject(root, "granularity", granularity);
+	cJSON_AddStringToObject(root, "domains", domains_str);
+	char* body = cJSON_PrintUnformatted(root);
 
-     Qiniu_Json* jsonRet = NULL;   
+	Qiniu_Json* jsonRet = NULL;
 
-     err = Qiniu_Client_CallWithBuffer2(
-         self,&jsonRet,url,body,strlen(body),"application/json");
+	err = Qiniu_Client_CallWithBuffer2(
+		self, &jsonRet, url, body, strlen(body), "application/json");
 
-    
-     if (err.code == 200) {
-		 ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-         ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-         //ret->time = Qiniu_Json_GetString(jsonRet, "time", "");
-         //ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
-	 }
 
-     Qiniu_Free(url);
-     //Qiniu_Free(domains_str);
-     Qiniu_Free(body);
-     cJSON_Delete(root);
+	if (err.code == 200) {
+		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+		//ret->time = Qiniu_Json_GetString(jsonRet, "time", "");
+		//ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+	}
 
-     return err;
- }
+	Qiniu_Free(url);
+	//Qiniu_Free(domains_str);
+	Qiniu_Free(body);
+	cJSON_Delete(root);
+
+	return err;
+}
 
 // TODO: Parse `ret->time` and `ret->data` fields
 QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetBandwidthData(
-    Qiniu_Client* self,
-    Qiniu_Cdn_FluxBandwidthRet* ret, 
-    const char* startDate,
-    const char* endDate,
-    const char* granularity,
-    const char* domains[],
-    const int num)
+	Qiniu_Client* self,
+	Qiniu_Cdn_FluxBandwidthRet* ret,
+	const char* startDate,
+	const char* endDate,
+	const char* granularity,
+	const char* domains[],
+	const int num)
 {
-     Qiniu_Error err;
+	Qiniu_Error err;
 
-     char* path = "/v2/tune/bandwidth";
-     char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+	char* path = "/v2/tune/bandwidth";
+	char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
 
-     char* domains_str = Qiniu_String_Join(";",domains,num);
+	char* domains_str = Qiniu_String_Join(";", domains, num);
 
-     cJSON* root = cJSON_CreateObject();
-     cJSON_AddStringToObject(root,"startDate",startDate);   
-     cJSON_AddStringToObject(root,"endDate",endDate);
-     cJSON_AddStringToObject(root,"granularity",granularity);    
-     cJSON_AddStringToObject(root,"domains",domains_str);
-     char* body = cJSON_PrintUnformatted(root);
+	cJSON* root = cJSON_CreateObject();
+	cJSON_AddStringToObject(root, "startDate", startDate);
+	cJSON_AddStringToObject(root, "endDate", endDate);
+	cJSON_AddStringToObject(root, "granularity", granularity);
+	cJSON_AddStringToObject(root, "domains", domains_str);
+	char* body = cJSON_PrintUnformatted(root);
 
-     Qiniu_Json* jsonRet = NULL;   
+	Qiniu_Json* jsonRet = NULL;
 
-     err = Qiniu_Client_CallWithBuffer2(
-         self,&jsonRet,url,body,strlen(body),"application/json");
+	err = Qiniu_Client_CallWithBuffer2(
+		self, &jsonRet, url, body, strlen(body), "application/json");
 
-    
-     if (err.code == 200) {
-		 ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-         ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-         //ret->time = Qiniu_Json_GetString(jsonRet, "time", "");
-         //ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
-	 }
 
-     Qiniu_Free(url);
-     Qiniu_Free(domains_str);
-     Qiniu_Free(body);
-     cJSON_Delete(root);
+	if (err.code == 200) {
+		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+		//ret->time = Qiniu_Json_GetString(jsonRet, "time", "");
+		//ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+	}
 
-     return err;
+	Qiniu_Free(url);
+	Qiniu_Free(domains_str);
+	Qiniu_Free(body);
+	cJSON_Delete(root);
+
+	return err;
 }
 
 // TODO: Parse `ret->data` field
 QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetLogList(
-    Qiniu_Client* self,
-    Qiniu_Cdn_LogListRet* ret,
-    const char* day,
-    const char* domains[],
-    const int num)
+	Qiniu_Client* self,
+	Qiniu_Cdn_LogListRet* ret,
+	const char* day,
+	const char* domains[],
+	const int num)
 {
-     Qiniu_Error err;
+	Qiniu_Error err;
 
-     char* path = "/v2/tune/log/list";
-     char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
+	char* path = "/v2/tune/log/list";
+	char* url = Qiniu_String_Concat2(QINIU_FUSION_HOST, path);
 
-     char* domains_str = Qiniu_String_Join(";",domains,num);
+	char* domains_str = Qiniu_String_Join(";", domains, num);
 
-     cJSON* root = cJSON_CreateObject();
-     cJSON_AddStringToObject(root,"day",day);      
-     cJSON_AddStringToObject(root,"domains",domains_str);
-     char* body = cJSON_PrintUnformatted(root);
+	cJSON* root = cJSON_CreateObject();
+	cJSON_AddStringToObject(root, "day", day);
+	cJSON_AddStringToObject(root, "domains", domains_str);
+	char* body = cJSON_PrintUnformatted(root);
 
-     Qiniu_Json* jsonRet = NULL;   
+	Qiniu_Json* jsonRet = NULL;
 
-     err = Qiniu_Client_CallWithBuffer2(
-         self,&jsonRet,url,body,strlen(body),"application/json");
+	err = Qiniu_Client_CallWithBuffer2(
+		self, &jsonRet, url, body, strlen(body), "application/json");
 
-    
-     if (err.code == 200) {
-		 ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
-         ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
-         //ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
-	 }
 
-     Qiniu_Free(url);
-     Qiniu_Free(domains_str);
-     Qiniu_Free(body);
-     cJSON_Delete(root);
+	if (err.code == 200) {
+		ret->code = Qiniu_Json_GetInt(jsonRet, "code", 0);
+		ret->error = Qiniu_Json_GetString(jsonRet, "error", "");
+		//ret->data = Qiniu_Json_GetObjectItem(jsonRet, "data", "");
+	}
 
-     return err;
+	Qiniu_Free(url);
+	Qiniu_Free(domains_str);
+	Qiniu_Free(body);
+	cJSON_Delete(root);
+
+	return err;
 }

--- a/qiniu/cdn.h
+++ b/qiniu/cdn.h
@@ -3,7 +3,7 @@
  Name        : cdn.h
  Author      : Qiniu.com
  Copyright   : 2017(c) Shanghai Qiniu Information Technologies Co., Ltd.
- Description : 
+ Description :
  ============================================================================
  */
 
@@ -14,45 +14,45 @@
 #include "macro.h"
 #include "http.h"
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+ #ifdef __cplusplus
+ extern "C"
+ {
+ #endif
 
 typedef struct _Qiniu_Cdn_RefreshRet {
 	int    code;
 	char*  error;
-    char*  requestId;
-    char** invalidUrls;
-    char** invalidDirs;
-    int    urlQuotaDay;
-    int    urlSurplusDay;
-    int    dirQuotaDay;
-    int    dirSurplusDay;
+	char*  requestId;
+	char** invalidUrls;
+	char** invalidDirs;
+	int    urlQuotaDay;
+	int    urlSurplusDay;
+	int    dirQuotaDay;
+	int    dirSurplusDay;
 
 } Qiniu_Cdn_RefreshRet;
 
 typedef struct _Qiniu_Cdn_PrefetchRet {
 	int    code;
 	char*  error;
-    char*  requestId;
-    char** invalidUrls;
-    int    quotaDay;
-    int    surplusDay;
+	char*  requestId;
+	char** invalidUrls;
+	int    quotaDay;
+	int    surplusDay;
 
 } Qiniu_Cdn_PrefetchRet;
 
 typedef struct _Qiniu_Cdn_FluxBandwidthRet {
-    int    code;
-    char*  error;
-    char** time;
-    void** data;
+	int    code;
+	char*  error;
+	char** time;
+	void** data;
 }Qiniu_Cdn_FluxBandwidthRet;
 
 typedef struct _Qiniu_Cdn_LogListRet {
-    int    code;
-    char*  error;
-    void** data;
+	int    code;
+	char*  error;
+	void** data;
 }Qiniu_Cdn_LogListRet;
 
 #pragma pack(1)
@@ -79,13 +79,13 @@ QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_RefreshDirs(Qiniu_Client* self, Qiniu_
 QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_PrefetchUrls(Qiniu_Client* self, Qiniu_Cdn_PrefetchRet* ret, const char* urls[], const int num);
 
 QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetFluxData(Qiniu_Client* self, Qiniu_Cdn_FluxBandwidthRet* ret,
- const char* startDate, const char* endDate,const char* granularity, const char* domains[], const int num);
+	const char* startDate, const char* endDate, const char* granularity, const char* domains[], const int num);
 
-QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetBandwidthData(Qiniu_Client* self, Qiniu_Cdn_FluxBandwidthRet* ret, 
- const char* startDate, const char* endDate,const char* granularity, const char* domains[], const int num);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetBandwidthData(Qiniu_Client* self, Qiniu_Cdn_FluxBandwidthRet* ret,
+	const char* startDate, const char* endDate, const char* granularity, const char* domains[], const int num);
 
-QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetLogList(Qiniu_Client* self, Qiniu_Cdn_LogListRet* ret, 
-const char* day, const char* domains[], const int num);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetLogList(Qiniu_Client* self, Qiniu_Cdn_LogListRet* ret,
+	const char* day, const char* domains[], const int num);
 
 //=====================================================================
 

--- a/qiniu/cdn.h
+++ b/qiniu/cdn.h
@@ -1,0 +1,96 @@
+/*
+ ============================================================================
+ Name        : cdn.h
+ Author      : Qiniu.com
+ Copyright   : 2017(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description : 
+ ============================================================================
+ */
+
+#ifndef QINIU_CDN_H
+#define QINIU_CDN_H
+
+#include "base.h"
+#include "macro.h"
+#include "http.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct _Qiniu_Cdn_RefreshRet {
+	int    code;
+	char*  error;
+    char*  requestId;
+    char** invalidUrls;
+    char** invalidDirs;
+    int    urlQuotaDay;
+    int    urlSurplusDay;
+    int    dirQuotaDay;
+    int    dirSurplusDay;
+
+} Qiniu_Cdn_RefreshRet;
+
+typedef struct _Qiniu_Cdn_PrefetchRet {
+	int    code;
+	char*  error;
+    char*  requestId;
+    char** invalidUrls;
+    int    quotaDay;
+    int    surplusDay;
+
+} Qiniu_Cdn_PrefetchRet;
+
+typedef struct _Qiniu_Cdn_FluxBandwidthRet {
+    int    code;
+    char*  error;
+    char** time;
+    void** data;
+}Qiniu_Cdn_FluxBandwidthRet;
+
+typedef struct _Qiniu_Cdn_LogListRet {
+    int    code;
+    char*  error;
+    void** data;
+}Qiniu_Cdn_LogListRet;
+
+#pragma pack(1)
+
+QINIU_DLLAPI extern char * Qiniu_Cdn_MakeDownloadUrlWithDeadline(const char * key, const char * url, Qiniu_Uint64 deadline);
+
+#pragma pack()
+
+//=====================================================================
+// ADDED CDN FUNCTIONS:
+// 1. RefreshUrls
+// 2. RefreshDirs
+// 3. PrefetchUrls
+// 4. GetFluxData
+// 5. GetBandwidthData
+// 6. GetLogList
+// MODIFIED by fengyh 2017-03-23 17:26
+//======================================================================
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_RefreshUrls(Qiniu_Client* self, Qiniu_Cdn_RefreshRet* ret, const char* urls[], const int num);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_RefreshDirs(Qiniu_Client* self, Qiniu_Cdn_RefreshRet* ret, const char* dirs[], const int num);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_PrefetchUrls(Qiniu_Client* self, Qiniu_Cdn_PrefetchRet* ret, const char* urls[], const int num);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetFluxData(Qiniu_Client* self, Qiniu_Cdn_FluxBandwidthRet* ret,
+ const char* startDate, const char* endDate,const char* granularity, const char* domains[], const int num);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetBandwidthData(Qiniu_Client* self, Qiniu_Cdn_FluxBandwidthRet* ret, 
+ const char* startDate, const char* endDate,const char* granularity, const char* domains[], const int num);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Cdn_GetLogList(Qiniu_Client* self, Qiniu_Cdn_LogListRet* ret, 
+const char* day, const char* domains[], const int num);
+
+//=====================================================================
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // QINIU_CDN_H

--- a/qiniu/conf.c
+++ b/qiniu/conf.c
@@ -15,7 +15,9 @@ const char* QINIU_SECRET_KEY			= "<Dont send your secret key to anyone>";
 
 const char* QINIU_RS_HOST				= "http://rs.qiniu.com";
 const char* QINIU_UP_HOST				= "http://upload.qiniu.com";
+const char* QINIU_UC_HOST				= "http://uc.qbox.me";
 const char* QINIU_API_HOST				= "http://api.qiniu.com";
+const char* QINIU_FUSION_HOST           = "http://fusion.qiniuapi.com";
 
 /*============================================================================*/
 

--- a/qiniu/conf.h
+++ b/qiniu/conf.h
@@ -10,24 +10,21 @@
 #ifndef QINIU_CONF_H
 #define QINIU_CONF_H
 
+#include "macro.h"
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
-#if defined(USING_QINIU_LIBRARY_DLL)
-    #define QINIU_DLLIMPORT __declspec(dllimport)
-#else
-    #define QINIU_DLLIMPORT 
-#endif
+QINIU_DLLAPI extern const char* QINIU_ACCESS_KEY;
+QINIU_DLLAPI extern const char* QINIU_SECRET_KEY;
 
-
-QINIU_DLLIMPORT extern const char* QINIU_ACCESS_KEY;
-QINIU_DLLIMPORT extern const char* QINIU_SECRET_KEY;
-
-QINIU_DLLIMPORT extern const char* QINIU_RS_HOST;
-QINIU_DLLIMPORT extern const char* QINIU_UP_HOST;
-QINIU_DLLIMPORT extern const char* QINIU_API_HOST;
+QINIU_DLLAPI extern const char* QINIU_RS_HOST;
+QINIU_DLLAPI extern const char* QINIU_UP_HOST;
+QINIU_DLLAPI extern const char* QINIU_UC_HOST;
+QINIU_DLLAPI extern const char* QINIU_API_HOST;
+QINIU_DLLAPI extern const char* QINIU_FUSION_HOST;
 
 #ifdef __cplusplus
 }

--- a/qiniu/fop.h
+++ b/qiniu/fop.h
@@ -42,7 +42,7 @@ typedef struct _Qiniu_FOP_PfopRet {
 
 /* @endgist */
 
-Qiniu_Error Qiniu_FOP_Pfop(Qiniu_Client* self, Qiniu_FOP_PfopRet* ret, Qiniu_FOP_PfopArgs* args, char* fop[], int fopCount);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_FOP_Pfop(Qiniu_Client* self, Qiniu_FOP_PfopRet* ret, Qiniu_FOP_PfopArgs* args, char* fop[], int fopCount);
 
 /*============================================================================*/
 

--- a/qiniu/http.h
+++ b/qiniu/http.h
@@ -21,14 +21,14 @@ extern "C"
 {
 #endif
 
-void Qiniu_Global_Init(long flags);
-void Qiniu_Global_Cleanup();
+extern void Qiniu_Global_Init(long flags);
+extern void Qiniu_Global_Cleanup();
 
-void Qiniu_MacAuth_Init();
-void Qiniu_MacAuth_Cleanup();
+extern void Qiniu_MacAuth_Init();
+extern void Qiniu_MacAuth_Cleanup();
 
-void Qiniu_Servend_Init(long flags);
-void Qiniu_Servend_Cleanup();
+extern void Qiniu_Servend_Init(long flags);
+extern void Qiniu_Servend_Cleanup();
 
 #ifdef __cplusplus
 }
@@ -50,19 +50,24 @@ extern "C"
 {
 #endif
 
-void Qiniu_Mutex_Init(Qiniu_Mutex* self);
-void Qiniu_Mutex_Cleanup(Qiniu_Mutex* self);
+QINIU_DLLAPI extern void Qiniu_Mutex_Init(Qiniu_Mutex* self);
+QINIU_DLLAPI extern void Qiniu_Mutex_Cleanup(Qiniu_Mutex* self);
 
-void Qiniu_Mutex_Lock(Qiniu_Mutex* self);
-void Qiniu_Mutex_Unlock(Qiniu_Mutex* self);
+QINIU_DLLAPI extern void Qiniu_Mutex_Lock(Qiniu_Mutex* self);
+QINIU_DLLAPI extern void Qiniu_Mutex_Unlock(Qiniu_Mutex* self);
 
 /*============================================================================*/
 /* type Qiniu_Json */
 
 typedef struct cJSON Qiniu_Json;
 
-const char* Qiniu_Json_GetString(Qiniu_Json* self, const char* key, const char* defval);
-Qiniu_Int64 Qiniu_Json_GetInt64(Qiniu_Json* self, const char* key, Qiniu_Int64 defval);
+QINIU_DLLAPI extern const char* Qiniu_Json_GetString(Qiniu_Json* self, const char* key, const char* defval);
+QINIU_DLLAPI extern const char* Qiniu_Json_GetStringAt(Qiniu_Json* self, int n, const char* defval);
+QINIU_DLLAPI extern Qiniu_Int64 Qiniu_Json_GetInt64(Qiniu_Json* self, const char* key, Qiniu_Int64 defval);
+QINIU_DLLAPI extern int Qiniu_Json_GetBoolean(Qiniu_Json* self, const char* key, int defval);
+QINIU_DLLAPI extern Qiniu_Json* Qiniu_Json_GetObjectItem(Qiniu_Json* self, const char* key, Qiniu_Json* defval);
+QINIU_DLLAPI extern Qiniu_Json* Qiniu_Json_GetArrayItem(Qiniu_Json* self, int n, Qiniu_Json* defval);
+QINIU_DLLAPI extern void Qiniu_Json_Destroy(Qiniu_Json* self);
 
 /*============================================================================*/
 /* type Qiniu_Auth */
@@ -81,10 +86,12 @@ typedef struct _Qiniu_Auth {
 	Qiniu_Auth_Itbl* itbl;
 } Qiniu_Auth;
 
-extern Qiniu_Auth Qiniu_NoAuth;
+QINIU_DLLAPI extern Qiniu_Auth Qiniu_NoAuth;
 
 /*============================================================================*/
 /* type Qiniu_Client */
+
+struct _Qiniu_Rgn_RegionTable;
 
 typedef struct _Qiniu_Client {
 	void* curl;
@@ -96,28 +103,35 @@ typedef struct _Qiniu_Client {
 	// Use the following field to specify which NIC to use for sending packets.
 	const char* boundNic;
 
-    // Use the following field to specify the average transfer speed in bytes per second (Bps)
-    // that the transfer should be below during lowSpeedTime seconds for this SDK to consider
-    // it to be too slow and abort.
-    long lowSpeedLimit;
+	// Use the following field to specify the average transfer speed in bytes per second (Bps)
+	// that the transfer should be below during lowSpeedTime seconds for this SDK to consider
+	// it to be too slow and abort.
+	long lowSpeedLimit;
 
-    // Use the following field to specify the time in number seconds that
-    // the transfer speed should be below the logSpeedLimit for this SDK to consider it
-    // too slow and abort.
-    long lowSpeedTime;
+	// Use the following field to specify the time in number seconds that
+	// the transfer speed should be below the logSpeedLimit for this SDK to consider it
+	// too slow and abort.
+	long lowSpeedTime;
+
+	// Use the following field to manange information of multi-region.
+	struct _Qiniu_Rgn_RegionTable * regionTable;
 } Qiniu_Client;
 
-void Qiniu_Client_InitEx(Qiniu_Client* self, Qiniu_Auth auth, size_t bufSize);
-void Qiniu_Client_Cleanup(Qiniu_Client* self);
-void Qiniu_Client_BindNic(Qiniu_Client* self, const char* nic);
-void Qiniu_Client_SetLowSpeedLimit(Qiniu_Client* self, long lowSpeedLimit, long lowSpeedTime);
+QINIU_DLLAPI extern void Qiniu_Client_InitEx(Qiniu_Client* self, Qiniu_Auth auth, size_t bufSize);
+QINIU_DLLAPI extern void Qiniu_Client_Cleanup(Qiniu_Client* self);
+QINIU_DLLAPI extern void Qiniu_Client_BindNic(Qiniu_Client* self, const char* nic);
+QINIU_DLLAPI extern void Qiniu_Client_SetLowSpeedLimit(Qiniu_Client* self, long lowSpeedLimit, long lowSpeedTime);
 
-Qiniu_Error Qiniu_Client_Call(Qiniu_Client* self, Qiniu_Json** ret, const char* url);
-Qiniu_Error Qiniu_Client_CallNoRet(Qiniu_Client* self, const char* url);
-Qiniu_Error Qiniu_Client_CallWithBinary(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Client_Call(Qiniu_Client* self, Qiniu_Json** ret, const char* url);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Client_CallNoRet(Qiniu_Client* self, const char* url);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Client_CallWithBinary(
 	Qiniu_Client* self, Qiniu_Json** ret, const char* url,
 	Qiniu_Reader body, Qiniu_Int64 bodyLen, const char* mimeType);
-Qiniu_Error Qiniu_Client_CallWithBuffer(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Client_CallWithBuffer(
+	Qiniu_Client* self, Qiniu_Json** ret, const char* url,
+	const char* body, size_t bodyLen, const char* mimeType);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Client_CallWithBuffer2(
 	Qiniu_Client* self, Qiniu_Json** ret, const char* url,
 	const char* body, size_t bodyLen, const char* mimeType);
 
@@ -131,11 +145,11 @@ typedef struct _Qiniu_Mac {
 
 Qiniu_Auth Qiniu_MacAuth(Qiniu_Mac* mac);
 
-char* Qiniu_Mac_Sign(Qiniu_Mac* self, char* data);
-char* Qiniu_Mac_SignToken(Qiniu_Mac* self, char* data);
+QINIU_DLLAPI extern char* Qiniu_Mac_Sign(Qiniu_Mac* self, char* data);
+QINIU_DLLAPI extern char* Qiniu_Mac_SignToken(Qiniu_Mac* self, char* data);
 
-void Qiniu_Client_InitNoAuth(Qiniu_Client* self, size_t bufSize);
-void Qiniu_Client_InitMacAuth(Qiniu_Client* self, size_t bufSize, Qiniu_Mac* mac);
+QINIU_DLLAPI extern void Qiniu_Client_InitNoAuth(Qiniu_Client* self, size_t bufSize);
+QINIU_DLLAPI extern void Qiniu_Client_InitMacAuth(Qiniu_Client* self, size_t bufSize, Qiniu_Mac* mac);
 
 /*============================================================================*/
 

--- a/qiniu/io.h
+++ b/qiniu/io.h
@@ -11,6 +11,8 @@
 #define QINIU_IO_H
 
 #include "http.h"
+#include "region.h"
+#include "reader.h"
 
 #pragma pack(1)
 
@@ -42,6 +44,20 @@ typedef struct _Qiniu_Io_PutExtra {
 	// which returns a JSON object.
 	void* callbackRet;
 	Qiniu_Error (*callbackRetParser)(void*, Qiniu_Json*);
+
+	// For those who want to send request to specific host.
+	const char* upHost;
+	Qiniu_Uint32 upHostFlags;
+	const char* upBucket;
+	const char* accessKey;
+	const char* uptoken;
+
+	// For those who want to abort uploading data to server.
+	void * upAbortUserData;
+	Qiniu_Rd_FnAbort upAbortCallback;
+
+	// Use the following field to specify the size of an uploading file definitively.
+	size_t upFileSize;
 } Qiniu_Io_PutExtra;
 
 /*============================================================================*/
@@ -50,7 +66,10 @@ typedef struct _Qiniu_Io_PutExtra {
 typedef struct _Qiniu_Io_PutRet {
 	const char* hash;
 	const char* key;
+    const char* persistentId;
 } Qiniu_Io_PutRet;
+
+typedef size_t (*rdFunc)(void* buffer, size_t size, size_t n, void* rptr);
 
 /*============================================================================*/
 /* func Qiniu_Io_PutXXX */
@@ -59,13 +78,22 @@ typedef struct _Qiniu_Io_PutRet {
 #define QINIU_UNDEFINED_KEY		NULL
 #endif
 
-Qiniu_Error Qiniu_Io_PutFile(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Io_PutFile(
 	Qiniu_Client* self, Qiniu_Io_PutRet* ret,
 	const char* uptoken, const char* key, const char* localFile, Qiniu_Io_PutExtra* extra);
 
-Qiniu_Error Qiniu_Io_PutBuffer(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Io_PutBuffer(
 	Qiniu_Client* self, Qiniu_Io_PutRet* ret,
 	const char* uptoken, const char* key, const char* buf, size_t fsize, Qiniu_Io_PutExtra* extra);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Io_PutStream(
+    Qiniu_Client* self, 
+	Qiniu_Io_PutRet* ret,
+    const char* uptoken, const char* key, 
+	void* ctx, // 'ctx' is the same as rdr's last param
+	size_t fsize, 
+	rdFunc rdr, 
+	Qiniu_Io_PutExtra* extra);
 
 /*============================================================================*/
 

--- a/qiniu/macro.h
+++ b/qiniu/macro.h
@@ -1,0 +1,21 @@
+/*
+ ============================================================================
+ Name        : conf.h
+ Author      : Qiniu.com
+ Copyright   : 2012(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description : 
+ ============================================================================
+ */
+
+#ifndef QINIU_MACRO_H
+#define QINIU_MACRO_H
+
+#if defined(USING_QINIU_LIBRARY_DLL)
+    #define QINIU_DLLAPI __declspec(dllimport)
+#elif defined(COMPILING_QINIU_LIBRARY_DLL)
+    #define QINIU_DLLAPI __declspec(dllexport)
+#else
+    #define QINIU_DLLAPI 
+#endif
+
+#endif

--- a/qiniu/qetag.c
+++ b/qiniu/qetag.c
@@ -1,0 +1,399 @@
+#include <openssl/sha.h>
+
+#include "qetag.h"
+
+#define NO 0
+#define YES 1
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#pragma pack(1)
+
+#define BLOCK_ELEMENT_MAX_COUNT 16
+#define BLOCK_MAX_SIZE (1 << 22)
+
+typedef struct _Qiniu_Qetag_Block {
+    struct {
+        unsigned int capacity:23;
+        unsigned int done:1;
+        unsigned int reserved:8;
+    };
+
+    SHA_CTX sha1Ctx;
+} Qiniu_Qetag_Block;
+
+typedef struct _Qiniu_Qetag_Context
+{
+    unsigned short int blkElementCount;
+    unsigned short int blkUnused;
+    unsigned short int blkBegin;
+    unsigned short int blkEnd;
+
+    unsigned int blkCount;
+    Qiniu_Qetag_Block * blk;
+
+    SHA_CTX sha1Ctx;
+    Qiniu_Qetag_Block blkArray[1];
+} Qiniu_Qetag_Context;
+
+static Qiniu_Error Qiniu_Qetag_mergeBlocks(struct _Qiniu_Qetag_Context * ctx) {
+    Qiniu_Error err;
+    unsigned char digest[SHA_DIGEST_LENGTH];
+    struct _Qiniu_Qetag_Block * blk = NULL;
+
+    while (ctx->blkUnused < ctx->blkElementCount && ctx->blkArray[ctx->blkBegin].done == YES) {
+        blk = &ctx->blkArray[ctx->blkBegin];
+
+        if (SHA1_Final(digest, &blk->sha1Ctx) == 0) {
+            err.code = 9999;
+            err.message = "openssl internal error";
+            return err;
+        } // if
+        if (SHA1_Update(&ctx->sha1Ctx, digest, sizeof(digest)) == 0) {
+            err.code = 9999;
+            err.message = "openssl internal error";
+            return err;
+        } // if
+
+        blk->done = NO;
+        
+        ctx->blkBegin += 1;
+        if (ctx->blkBegin >= ctx->blkElementCount) {
+            ctx->blkBegin = 0;
+        }
+        ctx->blkUnused += 1;
+    } // while
+
+    err.code = 200;
+    err.message = "ok";
+    return err;
+} // Qiniu_Qetag_mergeBlocks
+
+static Qiniu_Error Qiniu_Qetag_allocateBlock(struct _Qiniu_Qetag_Context * ctx, struct _Qiniu_Qetag_Block ** blk)
+{
+    Qiniu_Error err;
+    struct _Qiniu_Qetag_Block * newBlk = NULL;
+
+    if (ctx->blkUnused == 0) {
+        err = Qiniu_Qetag_mergeBlocks(ctx);
+        if (err.code != 200) {
+            return err;
+        }
+
+        if (ctx->blkUnused == 0) {
+            *blk = NULL;
+            err.code = 9991;
+            err.message = "no enough blocks";
+            return err;
+        } // if
+    } // if
+
+    newBlk = &ctx->blkArray[ctx->blkEnd];
+    if (SHA1_Init(&newBlk->sha1Ctx) == 0) {
+        err.code = 9999;
+        err.message = "openssl internal error";
+        return err;
+    }
+
+    newBlk->done = NO;
+    newBlk->capacity = BLOCK_MAX_SIZE;
+
+    ctx->blkUnused -= 1;
+    ctx->blkEnd += 1;
+    if (ctx->blkEnd >= ctx->blkElementCount) {
+        ctx->blkEnd = 0;
+    }
+
+    *blk = newBlk;
+    err.code = 200;
+    err.message = "ok";
+    return err;
+} // Qiniu_Qetag_allocateBlock
+
+Qiniu_Error Qiniu_Qetag_New(struct _Qiniu_Qetag_Context ** ctx, unsigned int concurrency)
+{
+    Qiniu_Error err;
+    Qiniu_Qetag_Context * newCtx = NULL;
+
+    // 分配主结构体
+    if (concurrency < 1) {
+        concurrency = 1;
+    } else if (concurrency > BLOCK_ELEMENT_MAX_COUNT) {
+        concurrency = BLOCK_ELEMENT_MAX_COUNT;
+    } // if
+
+    newCtx = calloc(1, sizeof(*newCtx) + sizeof(newCtx->blkArray[0]) * (concurrency - 1));
+    if (newCtx == NULL) {
+        err.code = 9999;
+        err.message = "not enough memory";
+        return err;
+    }
+    newCtx->blkElementCount = concurrency;
+
+    err = Qiniu_Qetag_Reset(newCtx);
+    if (err.code != 200) {
+        Qiniu_Qetag_Destroy(newCtx);
+        return err;
+    }
+
+    *ctx = newCtx;
+    err.code = 200;
+    err.message = "ok";
+    return err;
+} // Qiniu_Qetag_New
+
+Qiniu_Error Qiniu_Qetag_Reset(struct _Qiniu_Qetag_Context * ctx)
+{
+    Qiniu_Error err;
+
+    if (SHA1_Init(&ctx->sha1Ctx) == 0) {
+        err.code = 9999;
+        err.message = "openssl internal error";
+        return err;
+    }
+
+    ctx->blkCount   = 0;
+    ctx->blkUnused  = ctx->blkElementCount;
+    ctx->blkBegin   = 0;
+    ctx->blkEnd     = 0;
+    ctx->blk        = NULL;
+
+    err = Qiniu_Qetag_allocateBlock(ctx, &ctx->blk);
+    if (err.code != 200) {
+        return err;
+    }
+
+    err.code = 200;
+    err.message = "ok";
+    return err;
+} // Qiniu_Qetag_Reset
+
+void Qiniu_Qetag_Destroy(struct _Qiniu_Qetag_Context * ctx)
+{
+    if (ctx) {
+        free(ctx);
+    } // if
+} // Qiniu_Qetag_Destroy
+
+Qiniu_Error Qiniu_Qetag_Update(struct _Qiniu_Qetag_Context * ctx, const char * buf, size_t bufSize)
+{
+    Qiniu_Error err;
+    const char * pos = buf;
+    size_t size = bufSize;
+    size_t copySize = 0;
+
+    while (size > 0) {
+        if (!ctx->blk) {
+            err = Qiniu_Qetag_allocateBlock(ctx, &ctx->blk);
+            if (err.code != 200) {
+                return err;
+            }
+        } // if
+
+        copySize = (size >= ctx->blk->capacity) ? ctx->blk->capacity : size;
+        if (copySize) {
+            err = Qiniu_Qetag_UpdateBlock(ctx->blk, pos, copySize, NULL);
+            if (err.code != 200) {
+                return err;
+            }
+
+            pos += copySize;
+            size -= copySize;
+        } // if
+
+        if (ctx->blk->capacity == 0) {
+            Qiniu_Qetag_CommitBlock(ctx, ctx->blk);
+            ctx->blk = NULL;
+        } // if
+    } // while
+
+    err.code = 200;
+    err.message = "ok";
+    return err;
+} // Qiniu_Qetag_Update
+
+Qiniu_Error Qiniu_Qetag_Final(struct _Qiniu_Qetag_Context * ctx, char ** digest)
+{
+    Qiniu_Error err;
+    unsigned char digestSummary[4 + SHA_DIGEST_LENGTH];
+    char * newDigest = NULL;
+
+    if (ctx->blk) {
+        Qiniu_Qetag_CommitBlock(ctx, ctx->blk);
+        ctx->blk = NULL;
+    } // if
+
+    if (ctx->blkCount <= 1) {
+        digestSummary[0] = 0x16;
+
+        if (SHA1_Final(&digestSummary[1], &ctx->blkArray[0].sha1Ctx) == 0) {
+            err.code = 9999;
+            err.message = "openssl internal error";
+            return err;
+        } // if
+    } else {
+        err = Qiniu_Qetag_mergeBlocks(ctx);
+        if (err.code != 200) {
+            return err;
+        }
+
+        digestSummary[0] = 0x96;
+        if (SHA1_Final(&digestSummary[1], &ctx->sha1Ctx) == 0) {
+            err.code = 9999;
+            err.message = "openssl internal error";
+            return err;
+        }
+    } // if
+
+    newDigest = Qiniu_Memory_Encode((const char *)digestSummary, 1 + SHA_DIGEST_LENGTH);
+    if (newDigest == NULL) {
+        err.code = 9999;
+        err.message = "no enough memory";
+        return err;
+    }
+
+    *digest = newDigest;
+    err.code = 200;
+    err.message = "ok";
+    return err;
+} // Qiniu_Qetag_Final
+
+Qiniu_Error Qiniu_Qetag_AllocateBlock(struct _Qiniu_Qetag_Context * ctx, struct _Qiniu_Qetag_Block ** blk, size_t * remainderSize)
+{
+    Qiniu_Error err;
+    
+    if (ctx->blk) {
+        *blk = ctx->blk;
+        ctx->blk = NULL;
+    } else {
+        err = Qiniu_Qetag_allocateBlock(ctx, blk);
+        if (err.code != 200) {
+            return err;
+        }
+    } // if
+
+    if (remainderSize) {
+        *remainderSize = (*blk)->capacity;
+    }
+    err.code = 200;
+    err.message = "ok";
+    return err;
+} // Qiniu_Qetag_AllocateBlock
+
+Qiniu_Error Qiniu_Qetag_UpdateBlock(struct _Qiniu_Qetag_Block * blk, const char * buf, size_t bufSize, size_t * remainderSize)
+{
+    Qiniu_Error err;
+
+    if (bufSize > 0) {
+        if (SHA1_Update(&blk->sha1Ctx, buf, bufSize) == 0) {
+            err.code = 9999;
+            err.message = "openssl internal error";
+            return err;
+        }
+        blk->capacity -= bufSize;
+    } // if
+
+    if (remainderSize) {
+        *remainderSize = blk->capacity;
+    }
+    err.code = 200;
+    err.message = "ok";
+    return err;
+} // Qiniu_Qetag_UpdateBlock
+
+void Qiniu_Qetag_CommitBlock(struct _Qiniu_Qetag_Context * ctx, struct _Qiniu_Qetag_Block * blk)
+{
+    if (blk->capacity < BLOCK_MAX_SIZE) {
+        blk->done = YES;
+        ctx->blkCount += 1;
+    } else {
+        blk->done = NO;
+    }
+} // Qiniu_Qetag_CommitBlock
+
+Qiniu_Error Qiniu_Qetag_DigestFile(const char * localFile, char ** digest)
+{
+    Qiniu_Error err;
+    Qiniu_Off_T offset = 0;
+    size_t readingBytes = (BLOCK_MAX_SIZE >> 2);
+    ssize_t readBytes = 0;
+	Qiniu_File * f = NULL;
+    struct _Qiniu_Qetag_Context * ctx = NULL;
+    char * buf = NULL;
+
+    // 1MB buffer
+    buf = malloc(readingBytes);
+    if (!buf) {
+        err.code = 9999;
+        err.message = "no enough memory";
+        return err;
+    }
+
+    err = Qiniu_Qetag_New(&ctx, 1);
+    if (err.code != 200) {
+        goto DIGESTFILE_NEWCTX_ERROR;
+    }
+
+	err = Qiniu_File_Open(&f, localFile);
+	if (err.code != 200) {
+        goto DIGESTFILE_OPEN_ERROR;
+	}
+
+    do {
+        readBytes = Qiniu_File_ReadAt(f, buf, readingBytes, offset);
+        if (readBytes < 0) {
+            err.code = 9990;
+            err.message = "failed in reading file";
+            goto DIGESTFILE_UPDATE_ERROR;
+        } else if (readBytes > 0) {
+            err = Qiniu_Qetag_Update(ctx, buf, readBytes);
+            if (err.code != 200) {
+                goto DIGESTFILE_UPDATE_ERROR;
+            }
+            offset += readBytes;
+        } // if
+    } while(readBytes > 0);
+
+    err = Qiniu_Qetag_Final(ctx, digest);
+
+DIGESTFILE_UPDATE_ERROR:
+    Qiniu_File_Close(f);
+
+DIGESTFILE_OPEN_ERROR:
+    Qiniu_Qetag_Destroy(ctx);
+
+DIGESTFILE_NEWCTX_ERROR:
+    free(buf);
+
+    return err;
+} // Qiniu_Qetag_DigestFile
+
+Qiniu_Error Qiniu_Qetag_DigestBuffer(const char * buf, size_t bufSize, char ** digest)
+{
+    Qiniu_Error err;
+    struct _Qiniu_Qetag_Context * ctx = NULL;
+
+    err = Qiniu_Qetag_New(&ctx, bufSize);
+    if (err.code != 200) {
+        return err;
+    }
+
+    err = Qiniu_Qetag_Update(ctx, buf, bufSize);
+    if (err.code != 200) {
+        Qiniu_Qetag_Destroy(ctx);
+        return err;
+    }
+
+    err = Qiniu_Qetag_Final(ctx, digest);
+    Qiniu_Qetag_Destroy(ctx);
+    return err;
+} // Qiniu_Qetag_DigestBuffer
+
+#pragma pack()
+
+#ifdef __cplusplus
+}
+#endif

--- a/qiniu/qetag.h
+++ b/qiniu/qetag.h
@@ -1,0 +1,47 @@
+/*
+ ============================================================================
+ Name        : qetag.h
+ Author      : Qiniu.com
+ Copyright   : 2012(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description : 
+ ============================================================================
+ */
+
+#include "base.h"
+#include "macro.h"
+
+#ifndef QINIU_QETAG_H
+#define QINIU_QETAG_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#pragma pack(1)
+
+struct _Qiniu_Qetag_Context;
+struct _Qiniu_Qetag_Block;
+
+// 底层函数
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Qetag_New(struct _Qiniu_Qetag_Context ** ctx, unsigned int concurrency);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Qetag_Reset(struct _Qiniu_Qetag_Context * ctx);
+QINIU_DLLAPI extern void Qiniu_Qetag_Destroy(struct _Qiniu_Qetag_Context * ctx);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Qetag_Update(struct _Qiniu_Qetag_Context * ctx, const char * buf, size_t bufSize);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Qetag_Final(struct _Qiniu_Qetag_Context * ctx, char ** digest);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Qetag_AllocateBlock(struct _Qiniu_Qetag_Context * ctx, struct _Qiniu_Qetag_Block ** blk, size_t * blkCapacity);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Qetag_UpdateBlock(struct _Qiniu_Qetag_Block * blk, const char * buf, size_t bufSize, size_t * blkCapacity);
+QINIU_DLLAPI extern void Qiniu_Qetag_CommitBlock(struct _Qiniu_Qetag_Context * ctx, struct _Qiniu_Qetag_Block * blk);
+
+// 单线程计算 QETAG
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Qetag_DigestFile(const char * localFile, char ** digest);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Qetag_DigestBuffer(const char * buf, size_t fsize, char ** digest);
+
+#pragma pack()
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* QINIU_QETAG_H */

--- a/qiniu/qiniu.def
+++ b/qiniu/qiniu.def
@@ -1,8 +1,14 @@
 EXPORTS
 	QINIU_ACCESS_KEY DATA
 	QINIU_SECRET_KEY DATA
-	QINIU_RS_HOST
-	QINIU_UP_HOST
+	QINIU_RS_HOST DATA
+	QINIU_UP_HOST DATA
+	QINIU_API_HOST DATA
+
+    Qiniu_OK DATA
+    Qiniu_Discard DATA
+    Qiniu_NoAuth DATA
+	Qiniu_Rio_ST DATA
 
 	Qiniu_Free
 	Qiniu_Count_Inc
@@ -14,6 +20,8 @@ EXPORTS
 	Qiniu_Memory_Encode
 	Qiniu_String_Encode
 	Qiniu_String_Decode
+    Qiniu_String_Dup
+    Qiniu_String_Join
 	Qiniu_PathEscape
 	Qiniu_QueryEscape
 	Qiniu_Seconds
@@ -40,7 +48,6 @@ EXPORTS
 	Qiniu_Buffer_Commit
 	Qiniu_Format_Register
 	Qiniu_Null_Fwrite
-	Qiniu_Discard
 	Qiniu_BufReader
 	Qiniu_BufReaderAt
 	Qiniu_TeeReader
@@ -69,7 +76,8 @@ EXPORTS
 	Qiniu_Mutex_Unlock
 	Qiniu_Json_GetString
 	Qiniu_Json_GetInt64
-	Qiniu_NoAuth
+    Qiniu_Json_Destroy
+    Qiniu_Json_GetInt
 	Qiniu_Client_InitEx
 	Qiniu_Client_Cleanup
 	Qiniu_Client_Call
@@ -79,13 +87,18 @@ EXPORTS
 	Qiniu_MacAuth
 	Qiniu_Mac_Sign
 	Qiniu_Mac_SignToken
+    Qiniu_Mac_Auth
+    Qiniu_Mac_Clone
+    Qiniu_Mac_Release
 	Qiniu_Client_InitNoAuth
 	Qiniu_Client_InitMacAuth
+    Qiniu_Client_SetLowSpeedLimit
+
+    Qiniu_FOP_Pfop
 
 	Qiniu_Io_PutFile
 	Qiniu_Io_PutBuffer
 
-	Qiniu_Rio_ST
 	Qiniu_Rio_SetSettings
 	Qiniu_Rio_BlockCount
 	Qiniu_Rio_Put

--- a/qiniu/reader.c
+++ b/qiniu/reader.c
@@ -1,0 +1,42 @@
+#include <curl/curl.h>
+
+#include "reader.h"
+
+QINIU_DLLAPI Qiniu_Error Qiniu_Rd_Reader_Open(Qiniu_Rd_Reader * rdr, const char * localFileName)
+{
+	Qiniu_Error err;
+	err = Qiniu_File_Open(&rdr->file, localFileName);
+	if (err.code != 200) {
+		return err;
+	} // if
+
+	rdr->offset = 0;
+	rdr->status = QINIU_RD_OK;
+
+	return Qiniu_OK;
+}
+
+QINIU_DLLAPI void Qiniu_Rd_Reader_Close(Qiniu_Rd_Reader * rdr)
+{
+	Qiniu_File_Close(rdr->file);
+}
+
+QINIU_DLLAPI size_t Qiniu_Rd_Reader_Callback(char * buffer, size_t size, size_t nitems, void * userData)
+{
+	ssize_t ret;
+	Qiniu_Rd_Reader * rdr = (Qiniu_Rd_Reader *)userData;
+
+	ret = Qiniu_File_ReadAt(rdr->file, buffer, size * nitems, rdr->offset);
+	if (ret < 0) {
+		rdr->status = QINIU_RD_ABORT_BY_READAT;
+		return CURL_READFUNC_ABORT;
+	} // if
+
+	if (rdr->abortCallback && rdr->abortCallback(rdr->abortUserData, buffer, ret)) {
+		rdr->status = QINIU_RD_ABORT_BY_CALLBACK;
+		return CURL_READFUNC_ABORT;
+	} // if
+
+	rdr->offset += ret;
+	return ret;
+}

--- a/qiniu/reader.h
+++ b/qiniu/reader.h
@@ -1,0 +1,56 @@
+/*
+ ============================================================================
+ Name		: reader.h
+ Author	  : Qiniu.com
+ Copyright   : 2012-2016(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description : 
+ ============================================================================
+ */
+
+#ifndef QINIU_READER_H
+#define QINIU_READER_H
+
+#include "base.h"
+
+#pragma pack(1)
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*============================================================================*/
+/* Declaration of Controllable Reader */
+
+typedef int (*Qiniu_Rd_FnAbort)(void * abortUserData, char * buf, size_t size);
+
+enum
+{
+	QINIU_RD_OK = 0,
+	QINIU_RD_ABORT_BY_CALLBACK,
+	QINIU_RD_ABORT_BY_READAT
+};
+
+typedef struct _Qiniu_Rd_Reader
+{
+	Qiniu_File * file;
+	Qiniu_Off_T offset;
+
+	int status;
+
+	void * abortUserData;
+	Qiniu_Rd_FnAbort abortCallback;
+} Qiniu_Rd_Reader;
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rd_Reader_Open(Qiniu_Rd_Reader * rdr, const char * localFileName);
+QINIU_DLLAPI extern void Qiniu_Rd_Reader_Close(Qiniu_Rd_Reader * rdr);
+
+QINIU_DLLAPI extern size_t Qiniu_Rd_Reader_Callback(char * buffer, size_t size, size_t nitems, void * rdr);
+
+#pragma pack()
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // QINIU_READER_H

--- a/qiniu/region.c
+++ b/qiniu/region.c
@@ -1,0 +1,530 @@
+/*
+ ============================================================================
+ Name        : region.c
+ Author      : Qiniu.com
+ Copyright   : 2016(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description :
+ ============================================================================
+ */
+
+#include <ctype.h>
+#include <curl/curl.h>
+
+#include "conf.h"
+#include "tm.h"
+#include "region.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+static Qiniu_Uint32 Qiniu_Rgn_enabling = 1;
+
+QINIU_DLLAPI extern void Qiniu_Rgn_Enable(void)
+{
+	Qiniu_Rgn_enabling = 1;
+} // Qiniu_Rgn_Enable
+
+QINIU_DLLAPI extern void Qiniu_Rgn_Disable(void)
+{
+	Qiniu_Rgn_enabling = 0;
+} // Qiniu_Rgn_Disable
+
+QINIU_DLLAPI extern Qiniu_Uint32 Qiniu_Rgn_IsEnabled(void)
+{
+	return (Qiniu_Rgn_enabling != 0);
+} // Qiniu_Rgn_IsEnabled
+
+static inline int Qiniu_Rgn_Info_isValidHost(const char * str)
+{
+	return (strstr(str, "http") == str) || (strstr(str, "HTTP") == str);
+} // Qiniu_Rgn_Info_isValidHost
+
+static void Qiniu_Rgn_Info_measureHosts(Qiniu_Json * root, Qiniu_Uint32 * bufLen, Qiniu_Uint32 * upHostCount, Qiniu_Uint32 * ioHostCount)
+{
+	int i = 0;
+	Qiniu_Json * arr = NULL;
+	const char * str = NULL;
+
+	arr = Qiniu_Json_GetObjectItem(root, "up", NULL);
+	if (arr) {
+		while ((str = Qiniu_Json_GetStringAt(arr, i++, NULL))) {
+			if (!Qiniu_Rgn_Info_isValidHost(str)) {
+				// Skip URLs which contains incorrect schema.
+				continue;
+			} // if
+			*bufLen += strlen(str) + 1;
+			*upHostCount += 1;
+		} // while
+	} // if
+
+	i = 0;
+	arr = Qiniu_Json_GetObjectItem(root, "io", NULL);
+	if (arr) {
+		while ((str = Qiniu_Json_GetStringAt(arr, i++, NULL))) {
+			if (!Qiniu_Rgn_Info_isValidHost(str)) {
+				// Skip URLs which contains incorrect schema.
+				continue;
+			} // if
+			*bufLen += strlen(str) + 1;
+			*ioHostCount += 1;
+		} // while
+	} // if
+} // Qiniu_Rgn_Info_measureHosts
+
+static void Qiniu_Rgn_Info_duplicateHosts(Qiniu_Json * root, Qiniu_Rgn_HostInfo *** upHosts, Qiniu_Rgn_HostInfo *** ioHosts, char ** strPos, Qiniu_Uint32 hostFlags)
+{
+	int i = 0;
+	Qiniu_Uint32 len = 0;
+	Qiniu_Json * arr = NULL;
+	const char * str = NULL;
+
+	arr = Qiniu_Json_GetObjectItem(root, "up", NULL);
+	if (arr) {
+		while ((str = Qiniu_Json_GetStringAt(arr, i++, NULL))) {
+			if (!Qiniu_Rgn_Info_isValidHost(str)) {
+				// Skip URLs which contains incorrect schema.
+				continue;
+			} // if
+			(**upHosts)->flags = hostFlags;
+			(**upHosts)->host = *strPos;
+			len = strlen(str);
+			memcpy((void*)(**upHosts)->host, str, len);
+			(*strPos) += len + 1;
+			*upHosts += 1;
+		} // while
+	} // if
+
+	i = 0;
+	arr = Qiniu_Json_GetObjectItem(root, "io", NULL);
+	if (arr) {
+		while ((str = Qiniu_Json_GetStringAt(arr, i++, NULL))) {
+			if (!Qiniu_Rgn_Info_isValidHost(str)) {
+				// Skip URLs which contains incorrect schema.
+				continue;
+			} // if
+			(**ioHosts)->flags = hostFlags | QINIU_RGN_DOWNLOAD_HOST;
+			(**ioHosts)->host = *strPos;
+			len = strlen(str);
+			memcpy((void*)(**ioHosts)->host, str, len);
+			(*strPos) += len + 1;
+			*ioHosts += 1;
+		} // while
+	} // if
+} // Qiniu_Rgn_Info_duplicateHosts
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Info_Fetch(Qiniu_Client * cli, Qiniu_Rgn_RegionInfo ** rgnInfo, const char * bucket, const char * accessKey)
+{
+	Qiniu_Error err;
+	Qiniu_Json * root = NULL;
+	Qiniu_Json * http = NULL;
+	Qiniu_Json * https = NULL;
+	Qiniu_Uint32 i = 0;
+	Qiniu_Uint32 upHostCount = 0;
+	Qiniu_Uint32 ioHostCount = 0;
+	Qiniu_Rgn_HostInfo ** upHosts = NULL;
+	Qiniu_Rgn_HostInfo ** ioHosts = NULL;
+	Qiniu_Rgn_RegionInfo * newRgnInfo = NULL;
+	char * buf = NULL;
+	char * pos = NULL;
+	char * url = NULL;
+	Qiniu_Uint32 bufLen = 0;
+
+	url = Qiniu_String_Format(256, "%s/v1/query?ak=%s&bucket=%s", QINIU_UC_HOST, accessKey, bucket);
+	err = Qiniu_Client_Call(cli, &root, url);
+	free(url);
+	if (err.code != 200) {
+		return err;
+	} // if
+
+	bufLen += sizeof(Qiniu_Rgn_RegionInfo) + strlen(bucket) + 1;
+
+	http = Qiniu_Json_GetObjectItem(root, "http", NULL);
+	if (http) {
+		Qiniu_Rgn_Info_measureHosts(http, &bufLen, &upHostCount, &ioHostCount);
+	} // if
+	https = Qiniu_Json_GetObjectItem(root, "https", NULL);
+	if (https) {
+		Qiniu_Rgn_Info_measureHosts(https, &bufLen, &upHostCount, &ioHostCount);
+	} // if
+	bufLen += (sizeof(Qiniu_Rgn_HostInfo*) + sizeof(Qiniu_Rgn_HostInfo)) * (upHostCount + ioHostCount);
+
+	buf = calloc(1, bufLen);
+	if (!buf) {
+		err.code = 499;
+		err.message = "No enough memory";
+		return err;
+	} // buf
+
+	pos = buf;
+
+	newRgnInfo = (Qiniu_Rgn_RegionInfo*)pos;
+	pos += sizeof(Qiniu_Rgn_RegionInfo);
+
+	newRgnInfo->upHosts = upHosts = (Qiniu_Rgn_HostInfo**)pos;
+	pos += sizeof(Qiniu_Rgn_HostInfo*) * upHostCount;
+
+	for (i = 0; i < upHostCount; i += 1) {
+		newRgnInfo->upHosts[i] = (Qiniu_Rgn_HostInfo*)(pos);
+		pos += sizeof(Qiniu_Rgn_HostInfo);
+	} // for
+
+	newRgnInfo->ioHosts = ioHosts = (Qiniu_Rgn_HostInfo**)pos;
+	pos += sizeof(Qiniu_Rgn_HostInfo*) * ioHostCount;
+
+	for (i = 0; i < ioHostCount; i += 1) {
+		newRgnInfo->ioHosts[i] = (Qiniu_Rgn_HostInfo*)(pos);
+		pos += sizeof(Qiniu_Rgn_HostInfo);
+	} // for
+
+	if (http) {
+		Qiniu_Rgn_Info_duplicateHosts(http, &upHosts, &ioHosts, &pos, QINIU_RGN_HTTP_HOST);
+	} // if
+	if (https) {
+		Qiniu_Rgn_Info_duplicateHosts(https, &upHosts, &ioHosts, &pos, QINIU_RGN_HTTPS_HOST);
+	} // if
+
+	newRgnInfo->upHostCount = upHostCount;
+	newRgnInfo->ioHostCount = ioHostCount;
+	newRgnInfo->global = Qiniu_Json_GetBoolean(root, "global", 0);
+	newRgnInfo->ttl = Qiniu_Json_GetInt64(root, "ttl", 86400) ;
+	newRgnInfo->nextTimestampToUpdate = newRgnInfo->ttl + Qiniu_Tm_LocalTime();
+
+	newRgnInfo->bucket = pos;
+	memcpy((void*)newRgnInfo->bucket, bucket, strlen(bucket));
+
+	*rgnInfo = newRgnInfo;
+	return Qiniu_OK;
+} // Qiniu_Rgn_Info_Fetch
+
+static Qiniu_Error Qiniu_Rgn_parseQueryArguments(const char * uptoken, char ** bucket, char ** accessKey)
+{
+	Qiniu_Error err;
+	const char * begin = uptoken;
+	const char * end = uptoken;
+	char * putPolicy = NULL;
+
+	end = strchr(begin, ':');
+	if (!end) {
+		err.code = 9989;
+		err.message = "Invalid uptoken";
+		return err;
+	} // if
+
+	*accessKey = calloc(1, end - begin + 1);
+	if (!*accessKey) {
+		err.code = 499;
+		err.message = "No enough memory";
+		return err;
+	} // if
+	memcpy(*accessKey, begin, end - begin);
+
+	begin = strchr(end + 1, ':');
+	if (!begin) {
+		free(*accessKey);
+		*accessKey = NULL;
+		err.code = 9989;
+		err.message = "Invalid uptoken";
+		return err;
+	} // if
+
+	putPolicy = Qiniu_String_Decode(begin);
+	begin = strstr(putPolicy, "\"scope\"");
+	if (!begin) {
+		free(*accessKey);
+		*accessKey = NULL;
+		err.code = 9989;
+		err.message = "Invalid uptoken";
+		return err;
+	} // if
+
+	begin += strlen("\"scope\"");
+	while (isspace(*begin) || *begin == ':') {
+		begin += 1;
+	} // while
+	if (*begin != '"') {
+		free(putPolicy);
+		free(*accessKey);
+		*accessKey = NULL;
+
+		err.code = 9989;
+		err.message = "Invalid uptoken";
+		return err;
+	} // if
+
+	begin += 1;
+	end = begin;
+	while (1) {
+		if (*end == ':' || (*end == '"' && *(end - 1) != '\\')) {
+			break;
+		} // if
+		end += 1;
+	} // while
+
+	*bucket = calloc(1, end - begin + 1);
+	if (!*bucket) {
+		free(putPolicy);
+		free(*accessKey);
+		*accessKey = NULL;
+
+		err.code = 499;
+		err.message = "No enough memory";
+		return err;
+	} // if
+	memcpy(*bucket, begin, end - begin);
+	return Qiniu_OK;
+} // Qiniu_Rgn_parseQueryArguments
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Info_FetchByUptoken(Qiniu_Client * cli, Qiniu_Rgn_RegionInfo ** rgnInfo, const char * uptoken)
+{
+	Qiniu_Error err;
+	char * bucket = NULL;
+	char * accessKey = NULL;
+
+	err = Qiniu_Rgn_parseQueryArguments(uptoken, &bucket, &accessKey);
+	if (err.code != 200) {
+		return err;
+	} // if
+
+	err = Qiniu_Rgn_Info_Fetch(cli, rgnInfo, bucket, accessKey);
+	free(bucket);
+	free(accessKey);
+	return err;
+} // Qiniu_Rgn_Info_FetchByUptoken
+
+QINIU_DLLAPI extern void Qiniu_Rgn_Info_Destroy(Qiniu_Rgn_RegionInfo * rgnInfo)
+{
+	free(rgnInfo);
+} // Qiniu_Rgn_Info_Destroy
+
+QINIU_DLLAPI extern Qiniu_Uint32 Qiniu_Rgn_Info_HasExpirated(Qiniu_Rgn_RegionInfo * rgnInfo)
+{
+	return (rgnInfo->nextTimestampToUpdate <= Qiniu_Tm_LocalTime());
+} // Qiniu_Rgn_Info_HasExpirated
+
+QINIU_DLLAPI extern Qiniu_Uint32 Qiniu_Rgn_Info_CountUpHost(Qiniu_Rgn_RegionInfo * rgnInfo)
+{
+	return rgnInfo->upHostCount;
+} // Qiniu_Rgn_Info_CountUpHost
+
+QINIU_DLLAPI extern Qiniu_Uint32 Qiniu_Rgn_Info_CountIoHost(Qiniu_Rgn_RegionInfo * rgnInfo)
+{
+	return rgnInfo->ioHostCount;
+} // Qiniu_Rgn_Info_CountIoHost
+
+QINIU_DLLAPI extern const char * Qiniu_Rgn_Info_GetHost(Qiniu_Rgn_RegionInfo * rgnInfo, Qiniu_Uint32 n, Qiniu_Uint32 hostFlags)
+{
+	if ((hostFlags & QINIU_RGN_HTTPS_HOST) == 0) {
+		hostFlags |= QINIU_RGN_HTTP_HOST;
+	} // if
+	if (hostFlags & QINIU_RGN_DOWNLOAD_HOST) {
+		if (n < rgnInfo->ioHostCount && (rgnInfo->ioHosts[n]->flags & hostFlags) == hostFlags) {
+			return rgnInfo->ioHosts[n]->host;
+		} // if
+	} else {
+		if (n < rgnInfo->upHostCount && (rgnInfo->upHosts[n]->flags & hostFlags) == hostFlags) {
+			return rgnInfo->upHosts[n]->host;
+		} // if
+	} // if
+	return NULL;
+} // Qiniu_Rgn_Info_GetHost
+
+QINIU_DLLAPI extern Qiniu_Rgn_RegionTable * Qiniu_Rgn_Table_Create(void)
+{
+	Qiniu_Rgn_RegionTable * new_tbl = NULL;
+
+	new_tbl = calloc(1, sizeof(Qiniu_Rgn_RegionTable));
+	if (!new_tbl) {
+		return NULL;
+	} // if
+
+	return new_tbl;
+} // Qiniu_Rgn_Create
+
+QINIU_DLLAPI extern void Qiniu_Rgn_Table_Destroy(Qiniu_Rgn_RegionTable * rgnTable)
+{
+	Qiniu_Uint32 i = 0;
+	if (rgnTable) {
+		for (i = 0; i < rgnTable->rgnCount; i += 1) {
+			Qiniu_Rgn_Info_Destroy(rgnTable->regions[i]);
+		} // for
+		free(rgnTable);
+	} // if
+} // Qiniu_Rgn_Destroy
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_FetchAndUpdate(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Client * cli, const char * bucket, const char * accessKey)
+{
+	Qiniu_Error err;
+	Qiniu_Rgn_RegionInfo * newRgnInfo = NULL;
+	
+	err = Qiniu_Rgn_Info_Fetch(cli, &newRgnInfo, bucket, accessKey);
+	if (err.code != 200) {
+		return err;
+	} // if
+
+	return Qiniu_Rgn_Table_SetRegionInfo(rgnTable, newRgnInfo);
+} // Qiniu_Rgn_Table_FetchAndUpdate
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_FetchAndUpdateByUptoken(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Client * cli, const char * uptoken)
+{
+	Qiniu_Error err;
+	Qiniu_Rgn_RegionInfo * newRgnInfo = NULL;
+	
+	err = Qiniu_Rgn_Info_FetchByUptoken(cli, &newRgnInfo, uptoken);
+	if (err.code != 200) {
+		return err;
+	} // if
+
+	return Qiniu_Rgn_Table_SetRegionInfo(rgnTable, newRgnInfo);
+} // Qiniu_Rgn_Table_FetchAndUpdateByUptoken
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_SetRegionInfo(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Rgn_RegionInfo * rgnInfo)
+{
+	Qiniu_Error err;
+	Qiniu_Uint32 i = 0;
+	Qiniu_Rgn_RegionInfo ** newRegions = NULL;
+
+	for (i = 0; i < rgnTable->rgnCount; i += 1) {
+		if (strcmp(rgnTable->regions[i]->bucket, rgnInfo->bucket) == 0) {
+			Qiniu_Rgn_Info_Destroy(rgnTable->regions[i]);
+			rgnTable->regions[i] = rgnInfo;
+			return Qiniu_OK;
+		} // if
+	} // for
+
+	newRegions = calloc(1, sizeof(Qiniu_Rgn_RegionInfo *) * rgnTable->rgnCount + 1);
+	if (!newRegions) {
+		err.code = 499;
+		err.message = "No enough memory";
+		return err;
+	} // if
+
+	if (rgnTable->rgnCount > 0) {
+		memcpy(newRegions, rgnTable->regions, sizeof(Qiniu_Rgn_RegionInfo *) * rgnTable->rgnCount);
+	} // if
+	newRegions[rgnTable->rgnCount] = rgnInfo;
+
+	free(rgnTable->regions);
+	rgnTable->regions = newRegions;
+	rgnTable->rgnCount += 1;
+	
+	return Qiniu_OK;
+} // Qiniu_Rgn_Table_SetRegionInfo
+
+QINIU_DLLAPI extern Qiniu_Rgn_RegionInfo * Qiniu_Rgn_Table_GetRegionInfo(Qiniu_Rgn_RegionTable * rgnTable, const char * bucket)
+{
+	Qiniu_Uint32 i = 0;
+	for (i = 0; i < rgnTable->rgnCount; i += 1) {
+		if (strcmp(rgnTable->regions[i]->bucket, bucket) == 0) {
+			return rgnTable->regions[i];
+		} // if
+	} // for
+	return NULL;
+} // Qiniu_Rgn_Table_GetRegionInfo
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_GetHost(
+	Qiniu_Rgn_RegionTable * rgnTable,
+	Qiniu_Client * cli,
+	const char * bucket,
+	const char * accessKey,
+	Qiniu_Uint32 hostFlags,
+	const char ** upHost,
+	Qiniu_Rgn_HostVote * vote)
+{
+	Qiniu_Error err;
+	Qiniu_Rgn_RegionInfo * rgnInfo = NULL;
+	Qiniu_Rgn_RegionInfo * newRgnInfo = NULL;
+
+	memset(vote, 0, sizeof(Qiniu_Rgn_HostVote));
+	rgnInfo = Qiniu_Rgn_Table_GetRegionInfo(rgnTable, bucket);
+	if (!rgnInfo || Qiniu_Rgn_Info_HasExpirated(rgnInfo)) {
+		err = Qiniu_Rgn_Info_Fetch(cli, &newRgnInfo, bucket, accessKey);
+		if (err.code != 200) {
+			return err;
+		} // if
+
+		err = Qiniu_Rgn_Table_SetRegionInfo(rgnTable, newRgnInfo);
+		if (err.code != 200) {
+			return err;
+		} // if
+
+		rgnInfo = newRgnInfo;
+	} // if
+
+	if ((hostFlags & QINIU_RGN_HTTPS_HOST) == 0) {
+		hostFlags |= QINIU_RGN_HTTP_HOST;
+	} // if
+	*upHost = Qiniu_Rgn_Info_GetHost(rgnInfo, 0, hostFlags);
+
+	if (vote) {
+		vote->rgnInfo = rgnInfo;
+		vote->host = &rgnInfo->upHosts[0];
+		vote->hostFlags = hostFlags;
+		vote->hosts = rgnInfo->upHosts;
+		vote->hostCount = rgnInfo->upHostCount;
+	} // if
+	return Qiniu_OK;
+} // Qiniu_Rgn_Table_GetHost
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_GetHostByUptoken(
+	Qiniu_Rgn_RegionTable * rgnTable,
+	Qiniu_Client * cli,
+	const char * uptoken,
+	Qiniu_Uint32 hostFlags,
+	const char ** upHost,
+	Qiniu_Rgn_HostVote * vote)
+{
+	Qiniu_Error err;
+	char * bucket = NULL;
+	char * accessKey = NULL;
+
+	err = Qiniu_Rgn_parseQueryArguments(uptoken, &bucket, &accessKey);
+	if (err.code != 200) {
+		return err;
+	} // if
+
+	err = Qiniu_Rgn_Table_GetHost(rgnTable, cli, bucket, accessKey, hostFlags, upHost, vote);
+	free(bucket);
+	free(accessKey);
+	return Qiniu_OK;
+} // Qiniu_Rgn_Table_GetHostByUptoken
+
+static void Qiniu_Rgn_Vote_downgradeHost(Qiniu_Rgn_HostVote * vote)
+{
+	Qiniu_Rgn_HostInfo ** next = vote->host + 1;
+	Qiniu_Rgn_HostInfo * t = NULL;
+
+	while (next < (vote->hosts + vote->hostCount) && ((*next)->flags & vote->hostFlags) == vote->hostFlags) {
+		if ((*next)->voteCount >= (*vote->host)->voteCount) {
+			t = *next;
+			*next = *(vote->host);
+			*(vote->host) = t;
+		} // if
+		vote->host = next;
+		next += 1;
+	} // while
+} // Qiniu_Rgn_Vote_downgradeHost
+
+QINIU_DLLAPI extern void Qiniu_Rgn_Table_VoteHost(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Rgn_HostVote * vote, Qiniu_Error err)
+{
+	if (!vote->rgnInfo) {
+		return;
+	} // if
+	if (err.code >= 100) {
+		(*vote->host)->voteCount += 1;
+		return;
+	} // if
+	switch (err.code) {
+		case CURLE_UNSUPPORTED_PROTOCOL:
+		case CURLE_COULDNT_RESOLVE_PROXY:
+		case CURLE_COULDNT_RESOLVE_HOST:
+		case CURLE_COULDNT_CONNECT:
+			(*vote->host)->voteCount /= 4;
+			Qiniu_Rgn_Vote_downgradeHost(vote);
+			break;
+
+		default:
+			break;
+	} // switch
+} // Qiniu_Rgn_VoteHost

--- a/qiniu/region.h
+++ b/qiniu/region.h
@@ -1,0 +1,93 @@
+/*
+ ============================================================================
+ Name		: region.h
+ Author	  : Qiniu.com
+ Copyright   : 2016(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description : 
+ ============================================================================
+ */
+
+#ifndef QINIU_REGION_H
+#define QINIU_REGION_H
+
+#include "http.h"
+
+#pragma pack(1)
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+QINIU_DLLAPI extern void Qiniu_Rgn_Enable(void);
+QINIU_DLLAPI extern void Qiniu_Rgn_Disable(void);
+QINIU_DLLAPI extern Qiniu_Uint32 Qiniu_Rgn_IsEnabled(void);
+
+enum {
+	QINIU_RGN_HTTP_HOST         = 0x0001,
+	QINIU_RGN_HTTPS_HOST        = 0x0002,
+	QINIU_RGN_CDN_HOST          = 0x0004,
+	QINIU_RGN_DOWNLOAD_HOST     = 0x0008
+};
+
+typedef struct _Qiniu_Rgn_HostInfo {
+	const char * host;
+	Qiniu_Uint32 flags;
+	Qiniu_Uint32 voteCount;
+} Qiniu_Rgn_HostInfo;
+
+typedef struct _Qiniu_Rgn_RegionInfo {
+	Qiniu_Uint64 nextTimestampToUpdate;
+
+	const char * bucket;
+
+	Qiniu_Int64 ttl;
+	Qiniu_Int64 global;
+
+	Qiniu_Uint32 upHostCount;
+	Qiniu_Rgn_HostInfo ** upHosts;
+
+	Qiniu_Uint32 ioHostCount;
+	Qiniu_Rgn_HostInfo ** ioHosts;
+} Qiniu_Rgn_RegionInfo;
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Info_Fetch(Qiniu_Client * cli, Qiniu_Rgn_RegionInfo ** rgnInfo, const char * bucket, const char * accessKey);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Info_FetchByUptoken(Qiniu_Client * cli, Qiniu_Rgn_RegionInfo ** rgnInfo, const char * uptoken);
+QINIU_DLLAPI extern void Qiniu_Rgn_Info_Destroy(Qiniu_Rgn_RegionInfo * rgnInfo);
+QINIU_DLLAPI extern Qiniu_Uint32 Qiniu_Rgn_Info_HasExpirated(Qiniu_Rgn_RegionInfo * rgnInfo);
+QINIU_DLLAPI extern Qiniu_Uint32 Qiniu_Rgn_Info_CountUpHost(Qiniu_Rgn_RegionInfo * rgnInfo);
+QINIU_DLLAPI extern Qiniu_Uint32 Qiniu_Rgn_Info_CountIoHost(Qiniu_Rgn_RegionInfo * rgnInfo);
+QINIU_DLLAPI extern const char * Qiniu_Rgn_Info_GetHost(Qiniu_Rgn_RegionInfo * rgnInfo, Qiniu_Uint32 n, Qiniu_Uint32 hostFlags);
+QINIU_DLLAPI extern const char * Qiniu_Rgn_Info_GetIoHost(Qiniu_Rgn_RegionInfo * rgnInfo, Qiniu_Uint32 n, Qiniu_Uint32 hostFlags);
+
+typedef struct _Qiniu_Rgn_RegionTable {
+	Qiniu_Uint32 rgnCount;
+	Qiniu_Rgn_RegionInfo ** regions;
+} Qiniu_Rgn_RegionTable;
+
+typedef struct _Qiniu_Rgn_HostVote {
+	Qiniu_Rgn_RegionInfo * rgnInfo;
+	Qiniu_Rgn_HostInfo ** host;
+	Qiniu_Rgn_HostInfo ** hosts;
+	Qiniu_Uint32 hostCount;
+	Qiniu_Uint32 hostFlags;
+} Qiniu_Rgn_HostVote;
+
+QINIU_DLLAPI extern Qiniu_Rgn_RegionTable * Qiniu_Rgn_Table_Create(void);
+QINIU_DLLAPI extern void Qiniu_Rgn_Table_Destroy(Qiniu_Rgn_RegionTable * rgnTable);
+
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_FetchAndUpdate(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Client * cli, const char * bucket, const char * access_key);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_FetchAndUpdateByUptoken(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Client * cli, const char * uptoken);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_SetRegionInfo(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Rgn_RegionInfo * rgnInfo);
+QINIU_DLLAPI extern Qiniu_Rgn_RegionInfo * Qiniu_Rgn_Table_GetRegionInfo(Qiniu_Rgn_RegionTable * rgnTable, const char * bucket);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_GetHost(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Client * cli, const char * bucket, const char * accessKey, Qiniu_Uint32 hostFlags, const char ** upHost, Qiniu_Rgn_HostVote * vote);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rgn_Table_GetHostByUptoken(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Client * cli, const char * uptoken, Qiniu_Uint32 hostFlags, const char ** upHost, Qiniu_Rgn_HostVote * vote);
+QINIU_DLLAPI extern void Qiniu_Rgn_Table_VoteHost(Qiniu_Rgn_RegionTable * rgnTable, Qiniu_Rgn_HostVote * vote, Qiniu_Error err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#pragma pack()
+
+#endif // QINIU_REGION_H

--- a/qiniu/resumable_io.h
+++ b/qiniu/resumable_io.h
@@ -26,6 +26,7 @@ extern "C"
 #define Qiniu_Rio_UnmatchedChecksum		9900
 #define Qiniu_Rio_InvalidPutProgress	9901
 #define Qiniu_Rio_PutFailed				9902
+#define Qiniu_Rio_PutInterrupted		9903
 
 /*============================================================================*/
 /* type Qiniu_Rio_WaitGroup */
@@ -42,13 +43,19 @@ typedef struct _Qiniu_Rio_WaitGroup {
 	Qiniu_Rio_WaitGroup_Itbl* itbl;
 } Qiniu_Rio_WaitGroup;
 
+#if defined(_WIN32)
+
+Qiniu_Rio_WaitGroup Qiniu_Rio_MTWG_Create(void);
+
+#endif
+
 /*============================================================================*/
 /* type Qiniu_Rio_ThreadModel */
 
 typedef struct _Qiniu_Rio_ThreadModel_Itbl {
 	Qiniu_Rio_WaitGroup (*WaitGroup)(void* self);
 	Qiniu_Client* (*ClientTls)(void* self, Qiniu_Client* mc);
-	void (*RunTask)(void* self, void (*task)(void* params), void* params);
+	int (*RunTask)(void* self, void (*task)(void* params), void* params);
 } Qiniu_Rio_ThreadModel_Itbl;
 
 typedef struct _Qiniu_Rio_ThreadModel {
@@ -56,7 +63,7 @@ typedef struct _Qiniu_Rio_ThreadModel {
 	Qiniu_Rio_ThreadModel_Itbl* itbl;
 } Qiniu_Rio_ThreadModel;
 
-extern Qiniu_Rio_ThreadModel Qiniu_Rio_ST;
+QINIU_DLLAPI extern Qiniu_Rio_ThreadModel Qiniu_Rio_ST;
 
 /*============================================================================*/
 /* type Qiniu_Rio_Settings */
@@ -69,7 +76,7 @@ typedef struct _Qiniu_Rio_Settings {
 	Qiniu_Rio_ThreadModel threadModel;
 } Qiniu_Rio_Settings;
 
-void Qiniu_Rio_SetSettings(Qiniu_Rio_Settings* v);
+QINIU_DLLAPI extern void Qiniu_Rio_SetSettings(Qiniu_Rio_Settings* v);
 
 /*============================================================================*/
 /* type Qiniu_Rio_PutExtra */
@@ -119,6 +126,13 @@ typedef struct _Qiniu_Rio_PutExtra {
 	// (extra->xVarsList[i])[1] set as the value, e.g. "priceless".
 	const char* (*xVarsList)[2];
 	int xVarsCount;
+
+	// For those who want to send request to specific host.
+	const char* upHost;
+	Qiniu_Uint32 upHostFlags;
+	const char* upBucket;
+	const char* accessKey;
+	const char* uptoken;
 } Qiniu_Rio_PutExtra;
 
 /*============================================================================*/
@@ -129,7 +143,7 @@ typedef Qiniu_Io_PutRet Qiniu_Rio_PutRet;
 /*============================================================================*/
 /* func Qiniu_Rio_BlockCount */
 
-int Qiniu_Rio_BlockCount(Qiniu_Int64 fsize);
+QINIU_DLLAPI extern int Qiniu_Rio_BlockCount(Qiniu_Int64 fsize);
 
 /*============================================================================*/
 /* func Qiniu_Rio_PutXXX */
@@ -138,11 +152,11 @@ int Qiniu_Rio_BlockCount(Qiniu_Int64 fsize);
 #define QINIU_UNDEFINED_KEY		NULL
 #endif
 
-Qiniu_Error Qiniu_Rio_Put(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rio_Put(
 	Qiniu_Client* self, Qiniu_Rio_PutRet* ret,
 	const char* uptoken, const char* key, Qiniu_ReaderAt f, Qiniu_Int64 fsize, Qiniu_Rio_PutExtra* extra);
 
-Qiniu_Error Qiniu_Rio_PutFile(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_Rio_PutFile(
 	Qiniu_Client* self, Qiniu_Rio_PutRet* ret,
 	const char* uptoken, const char* key, const char* localFile, Qiniu_Rio_PutExtra* extra);
 

--- a/qiniu/rs.c
+++ b/qiniu/rs.c
@@ -65,6 +65,9 @@ char* Qiniu_RS_PutPolicy_Token(Qiniu_RS_PutPolicy* auth, Qiniu_Mac* mac)
 	if (auth->insertOnly) {
 		cJSON_AddNumberToObject(root, "insertOnly", auth->insertOnly);
 	}
+    if (auth->deleteAfterDays > 0) {
+		cJSON_AddNumberToObject(root, "deleteAfterDays", auth->deleteAfterDays);
+    }
 
 	if (auth->expires) {
 		expires = auth->expires;

--- a/qiniu/rs.h
+++ b/qiniu/rs.h
@@ -40,6 +40,7 @@ typedef struct _Qiniu_RS_PutPolicy {
     Qiniu_Uint32 detectMime;
     Qiniu_Uint32 insertOnly;
     Qiniu_Uint32 expires;
+    Qiniu_Uint32 deleteAfterDays;
 } Qiniu_RS_PutPolicy;
 
 /* @endgist */
@@ -48,9 +49,9 @@ typedef struct _Qiniu_RS_GetPolicy {
     Qiniu_Uint32 expires;
 } Qiniu_RS_GetPolicy;
 
-char* Qiniu_RS_PutPolicy_Token(Qiniu_RS_PutPolicy* policy, Qiniu_Mac* mac);
-char* Qiniu_RS_GetPolicy_MakeRequest(Qiniu_RS_GetPolicy* policy, const char* baseUrl, Qiniu_Mac* mac);
-char* Qiniu_RS_MakeBaseUrl(const char* domain, const char* key);
+QINIU_DLLAPI extern char* Qiniu_RS_PutPolicy_Token(Qiniu_RS_PutPolicy* policy, Qiniu_Mac* mac);
+QINIU_DLLAPI extern char* Qiniu_RS_GetPolicy_MakeRequest(Qiniu_RS_GetPolicy* policy, const char* baseUrl, Qiniu_Mac* mac);
+QINIU_DLLAPI extern char* Qiniu_RS_MakeBaseUrl(const char* domain, const char* key);
 
 /*============================================================================*/
 /* func Qiniu_RS_Stat */
@@ -66,25 +67,25 @@ typedef struct _Qiniu_RS_StatRet {
 
 /* @endgist */
 
-Qiniu_Error Qiniu_RS_Stat(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_RS_Stat(
 	Qiniu_Client* self, Qiniu_RS_StatRet* ret, const char* bucket, const char* key);
 
 /*============================================================================*/
 /* func Qiniu_RS_Delete */
 
-Qiniu_Error Qiniu_RS_Delete(Qiniu_Client* self, const char* bucket, const char* key);
+QINIU_DLLAPI extern Qiniu_Error Qiniu_RS_Delete(Qiniu_Client* self, const char* bucket, const char* key);
 
 /*============================================================================*/
 /* func Qiniu_RS_Copy */
 
-Qiniu_Error Qiniu_RS_Copy(Qiniu_Client* self, 
+QINIU_DLLAPI extern Qiniu_Error Qiniu_RS_Copy(Qiniu_Client* self, 
         const char* tableNameSrc, const char* keySrc, 
         const char* tableNameDest, const char* keyDest);
 
 /*============================================================================*/
 /* func Qiniu_RS_Move */
 
-Qiniu_Error Qiniu_RS_Move(Qiniu_Client* self, 
+QINIU_DLLAPI extern Qiniu_Error Qiniu_RS_Move(Qiniu_Client* self, 
         const char* tableNameSrc, const char* keySrc, 
         const char* tableNameDest, const char* keyDest);
 
@@ -112,7 +113,7 @@ typedef struct _Qiniu_RS_BatchStatRet {
 
 typedef int Qiniu_ItemCount;
 
-Qiniu_Error Qiniu_RS_BatchStat(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_RS_BatchStat(
         Qiniu_Client* self, Qiniu_RS_BatchStatRet* rets,
         Qiniu_RS_EntryPath* entries, Qiniu_ItemCount entryCount);
 
@@ -128,7 +129,7 @@ typedef struct _Qiniu_RS_BatchItemRet {
 
 /* @endgist */
 
-Qiniu_Error Qiniu_RS_BatchDelete(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_RS_BatchDelete(
         Qiniu_Client* self, Qiniu_RS_BatchItemRet* rets,
         Qiniu_RS_EntryPath* entries, Qiniu_ItemCount entryCount);
 
@@ -144,11 +145,11 @@ typedef struct _Qiniu_RS_EntryPathPair {
 
 /* @endgist */
 
-Qiniu_Error Qiniu_RS_BatchMove(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_RS_BatchMove(
         Qiniu_Client* self, Qiniu_RS_BatchItemRet* rets,
         Qiniu_RS_EntryPathPair* entryPairs, Qiniu_ItemCount entryCount);
 
-Qiniu_Error Qiniu_RS_BatchCopy(
+QINIU_DLLAPI extern Qiniu_Error Qiniu_RS_BatchCopy(
         Qiniu_Client* self, Qiniu_RS_BatchItemRet* rets,
         Qiniu_RS_EntryPathPair* entryPairs, Qiniu_ItemCount entryCount);
 

--- a/qiniu/tm.c
+++ b/qiniu/tm.c
@@ -1,0 +1,42 @@
+/*
+ ============================================================================
+ Name        : tm.c
+ Author      : Qiniu.com
+ Copyright   : 2016(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description :
+ ============================================================================
+ */
+
+#include "tm.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef _WIN32
+
+#include "../windows/emu_posix.h" // for type Qiniu_Posix_GetTimeOfDay
+
+QINIU_DLLAPI extern Qiniu_Uint64 Qiniu_Tm_LocalTime(void)
+{
+	return Qiniu_Posix_GetTimeOfDay();
+} // Qiniu
+
+#else
+
+#include <sys/time.h>
+
+QINIU_DLLAPI extern Qiniu_Uint64 Qiniu_Tm_LocalTime(void)
+{
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	return tv.tv_sec;
+} // Qiniu_Tm_LocalTime
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/qiniu/tm.h
+++ b/qiniu/tm.h
@@ -1,0 +1,26 @@
+/*
+ ============================================================================
+ Name        : tm.h
+ Author      : Qiniu.com
+ Copyright   : 2016(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description :
+ ============================================================================
+ */
+
+#ifndef QINIU_TIME_H
+#define QINIU_TIME_H
+
+#include "base.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+QINIU_DLLAPI extern Qiniu_Uint64 Qiniu_Tm_LocalTime(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // QINIU_TIME_H

--- a/windows/emu_posix.c
+++ b/windows/emu_posix.c
@@ -1,0 +1,89 @@
+/*
+ ============================================================================
+ Name        : emu_posix.c
+ Author      : Qiniu.com
+ Copyright   : 2012(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description : 
+ ============================================================================
+ */
+
+#include "emu_posix.h"
+#include <sys/stat.h>
+
+Qiniu_Posix_Handle Qiniu_Posix_Open(const char* file, int oflag, int mode)
+{
+	Qiniu_Posix_Handle fd = CreateFileA(
+		file, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_FLAG_RANDOM_ACCESS, NULL);
+	if (fd != INVALID_HANDLE_VALUE) {
+		errno = 0;
+		return fd;
+	}
+	errno = GetLastError();
+	return INVALID_HANDLE_VALUE;
+}
+
+ssize_t Qiniu_Posix_Pread2(Qiniu_Posix_Handle fd, void* buf, size_t nbytes, Emu_Off_T offset)
+{
+	BOOL ret;
+	DWORD nreaded = 0;
+	DWORD tmpErrno = 0;
+	OVERLAPPED o = {0};
+	o.Offset = (DWORD)(offset & (~(DWORD)0));
+	o.OffsetHigh = (DWORD)((offset >> 32) & (~(DWORD)0));
+	ret = ReadFile(fd, buf, nbytes, &nreaded, &o);
+	if (ret) {
+		errno = 0;
+		return nreaded;
+	}
+	tmpErrno = GetLastError();
+	if (tmpErrno == ERROR_HANDLE_EOF) {
+		// EOF
+		return 0;
+	}
+	errno = tmpErrno;
+	return -1;
+}
+
+static time_t fileTime2time_t(FILETIME ft)
+{
+	ULONGLONG ll = ft.dwLowDateTime | ((ULONGLONG)ft.dwHighDateTime << 32);
+	return (time_t)((ll - 116444736000000000) / 10000000);
+}
+
+int Qiniu_Posix_Fstat2(Qiniu_Posix_Handle fd, Emu_FileInfo* buf)
+{
+	BY_HANDLE_FILE_INFORMATION fi;
+	BOOL ret = GetFileInformationByHandle(fd, &fi);
+	if (ret) {
+		memset(buf, 0, sizeof(*buf));
+		buf->st_size = (Emu_Off_T)fi.nFileSizeLow | ((Emu_Off_T)fi.nFileSizeHigh << 32);
+		buf->st_atime = fileTime2time_t(fi.ftLastAccessTime);
+		buf->st_mtime = fileTime2time_t(fi.ftLastWriteTime);
+		buf->st_ctime = fileTime2time_t(fi.ftCreationTime);
+		errno = 0;
+		return 0;
+	}
+	errno = GetLastError();
+	return -1;
+}
+
+int Qiniu_Posix_Close(Qiniu_Posix_Handle fd)
+{
+	BOOL ret = CloseHandle(fd);
+	if (ret) {
+		errno = 0;
+		return 0;
+	}
+	errno = GetLastError();
+	return -1;
+}
+
+unsigned _int64 Qiniu_Posix_GetTimeOfDay(void)
+{
+	FILETIME tv;
+	ULARGE_INTEGER uint;
+	GetSystemTimeAsFileTime(&tv);
+	uint.u.LowPart = tv.dwLowDateTime;
+	uint.u.HighPart = tv.dwHighDateTime;
+	return uint.QuadPart / 1000L;
+} // Qiniu_Posix_GetTimeOfDay

--- a/windows/emu_posix.h
+++ b/windows/emu_posix.h
@@ -1,0 +1,57 @@
+/*
+ ============================================================================
+ Name        : emu_posix.h
+ Author      : Qiniu.com
+ Copyright   : 2012(c) Shanghai Qiniu Information Technologies Co., Ltd.
+ Description : 
+ ============================================================================
+ */
+#ifndef QINIU_EMU_POSIX_H
+#define QINIU_EMU_POSIX_H
+
+#include <windows.h>
+#include <sys/types.h>
+
+#include "macro.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*============================================================================*/
+/* type ssize_t */
+
+#ifndef _W64
+#define _W64
+#endif
+
+typedef _W64 int ssize_t;
+
+/*============================================================================*/
+/* type Qiniu_File */
+
+#define Qiniu_Posix_Handle			HANDLE
+#define Qiniu_Posix_InvalidHandle	INVALID_HANDLE_VALUE
+
+typedef _int64 Emu_Off_T;
+typedef struct _Emu_FileInfo {
+	Emu_Off_T       st_size;    /* total size, in bytes */
+	time_t          st_atime;   /* time of last access */
+	time_t          st_mtime;   /* time of last modification */
+	time_t          st_ctime;   /* time of last status change */
+} Emu_FileInfo;
+
+QINIU_DLLAPI extern Qiniu_Posix_Handle Qiniu_Posix_Open(const char* file, int oflag, int mode);
+QINIU_DLLAPI extern ssize_t Qiniu_Posix_Pread2(Qiniu_Posix_Handle fd, void* buf, size_t nbytes, Emu_Off_T offset);
+QINIU_DLLAPI extern int Qiniu_Posix_Fstat2(Qiniu_Posix_Handle fd, Emu_FileInfo* buf);
+QINIU_DLLAPI extern int Qiniu_Posix_Close(Qiniu_Posix_Handle fd);
+QINIU_DLLAPI extern unsigned _int64 Qiniu_Posix_GetTimeOfDay(void);
+
+/*============================================================================*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* QINIU_EMU_POSIX_H */


### PR DESCRIPTION
从[github/BluntBlade/20170111.timestamp_token](https://github.com/bluntblade/c-sdk/tree/20170111.timestamp_token)这个分支代码修改而来。

- **http**
  - 在Qiniu_Client_reset中添加设置CURLOPT_NOSIGNAL=1
  - 新增Qiniu_Client_CallWithBuffer2

- **CDN**新增功能：
  - `RefreshUrls`  
  - `RefreshDirs`  
  - `PrefetchUrls`  
  - `GetFluxData`  
  - `GetBandwidthData`  
  - `GetLogList`
  
- **io**新增PutStream函数

- 新增put_strem和cdn示例代码