### PR TITLE
bug

### DIFF
--- a/qiniu/auth_mac.c
+++ b/qiniu/auth_mac.c
@@ -50,7 +50,7 @@ static Qiniu_Error Qiniu_Mac_Auth(
 	char* auth;
 	char* enc_digest;
 	char digest[EVP_MAX_MD_SIZE + 1];
-	unsigned int dgtlen = sizeof(digest);
+	unsigned int digest_len = sizeof(digest);
 	Qiniu_Mac mac;
 
 	char const* path = strstr(url, "://");
@@ -84,7 +84,7 @@ static Qiniu_Error Qiniu_Mac_Auth(
 #endif
 
 #if OPENSSL_VERSION_NUMBER > 0x10100000
-    HMAC_CTX *ctx=HMAC_CTX_new();
+	HMAC_CTX *ctx=HMAC_CTX_new();
     HMAC_Init_ex(ctx, mac.secretKey, strlen(mac.secretKey), EVP_sha1(), NULL);
     HMAC_Update(ctx, path, strlen(path));
 	HMAC_Update(ctx, "\n", 1);
@@ -96,7 +96,7 @@ static Qiniu_Error Qiniu_Mac_Auth(
 #endif
 	
 
-	enc_digest = Qiniu_Memory_Encode(digest, dgtlen);
+	enc_digest = Qiniu_Memory_Encode(digest, digest_len);
 
 	auth = Qiniu_String_Concat("Authorization: QBox ", mac.accessKey, ":", enc_digest, NULL);
 	Qiniu_Free(enc_digest);
@@ -158,7 +158,7 @@ char* Qiniu_Mac_Sign(Qiniu_Mac* self, char* data)
 	char* sign;
 	char* encoded_digest;
 	char digest[EVP_MAX_MD_SIZE + 1];
-	unsigned int dgtlen = sizeof(digest);
+	unsigned int digest_len = sizeof(digest);
 	
 	Qiniu_Mac mac;
 
@@ -173,17 +173,17 @@ char* Qiniu_Mac_Sign(Qiniu_Mac* self, char* data)
 	HMAC_CTX_init(&ctx);
 	HMAC_Init_ex(&ctx, mac.secretKey, strlen(mac.secretKey), EVP_sha1(), NULL);
 	HMAC_Update(&ctx, data, strlen(data));
-	HMAC_Final(&ctx, digest, &dgtlen);
+	HMAC_Final(&ctx, digest, &digest_len);
 	HMAC_CTX_cleanup(&ctx);
 #endif
 #if OPENSSL_VERSION_NUMBER > 0x101000000
 	HMAC_CTX *ctx=HMAC_CTX_new();
     HMAC_Init_ex(ctx, mac.secretKey, strlen(mac.secretKey), EVP_sha1(), NULL);
     HMAC_Update(ctx, data, strlen(data));
-    HMAC_Final(ctx, digest, &dgtlen);
+    HMAC_Final(ctx, digest, &digest_len);
     HMAC_CTX_free(ctx);
 #endif
-	encoded_digest = Qiniu_Memory_Encode(digest, dgtlen);
+	encoded_digest = Qiniu_Memory_Encode(digest, digest_len);
 	sign = Qiniu_String_Concat3(mac.accessKey, ":", encoded_digest);
 	Qiniu_Free(encoded_digest);
 

--- a/qiniu/io.c
+++ b/qiniu/io.c
@@ -253,7 +253,7 @@ static Qiniu_Error Qiniu_Io_call_with_callback(
 Qiniu_Error Qiniu_Io_PutStream(
         Qiniu_Client *self, Qiniu_Io_PutRet *ret,
         const char *uptoken, const char *key,
-        void *ctx, size_t fsize, rdFunc rdr,
+        void *ctx, int64_t fsize, rdFunc rdr,
         Qiniu_Io_PutExtra *extra) {
     Qiniu_Io_form form;
     Qiniu_Io_form_init(&form, uptoken, key, &extra);
@@ -274,7 +274,8 @@ Qiniu_Error Qiniu_Io_PutStream(
             CURLFORM_COPYNAME, "file",
             CURLFORM_FILENAME, "filename",
             CURLFORM_STREAM, ctx,
-            CURLFORM_CONTENTSLENGTH, fsize,
+            //CURLFORM_CONTENTSLENGTH, fsize, //deprecated after 7.46.0
+	    CURLFORM_CONTENTLEN, fsize, //7.46.0 and later added
             CURLFORM_END);
 
     return Qiniu_Io_call_with_callback(self, ret, form.formpost, rdr, extra);

--- a/qiniu/io.h
+++ b/qiniu/io.h
@@ -82,7 +82,7 @@ QINIU_DLLAPI extern Qiniu_Error Qiniu_Io_PutStream(
 	Qiniu_Io_PutRet* ret,
     const char* uptoken, const char* key, 
 	void* ctx, // 'ctx' is the same as rdr's last param
-	size_t fsize, 
+	int64_t fsize, 
 	rdFunc rdr, 
 	Qiniu_Io_PutExtra* extra);
 


### PR DESCRIPTION
    formdata.c：源码
     case CURLFORM_CONTENTSLENGTH:
      current_form->contentslength =
        array_state?(size_t)array_value:(size_t)va_arg(params, long);
      break;

    case CURLFORM_CONTENTLEN:
      current_form->flags |= CURL_HTTPPOST_LARGE;
      current_form->contentslength =
        array_state?(curl_off_t)(size_t)array_value:va_arg(params, curl_off_t);
      break;
current_form->contentslength 是一个int64_t类型，不管32还是64位机器
CURLFORM_CONTENTSLENGTH 在32位机器上是一个问题， size_t是unsigned long是4 bytes length，所以case语句在fsize=-1时候转换在32位机器上肯定有问题
CURLFORM_CONTENTLEN 7.46.0添加的的，修复了这个问题。

这个也是在32位机器上使用PutStream接口发现的，当用-1传入的时候http header中的content-length是一个非常大的数2^36，导致nginx报错entity too large.