### PR TITLE
defaultChunkSize to 4MB

### DIFF
--- a/qiniu/resumable_io.c
+++ b/qiniu/resumable_io.c
@@ -16,7 +16,7 @@
 
 #define defaultTryTimes        3
 #define defaultWorkers        4
-#define defaultChunkSize    (2 * 1024 * 1024) // 2MB
+#define defaultChunkSize    (4 * 1024 * 1024) // 4MB
 
 /*============================================================================*/
 /* type Qiniu_Rio_ST - SingleThread */


### PR DESCRIPTION
分片上传时，创建块接口（POST /mkblk/<blockSize>）的请求头里Content-Length字段是通过defaultChunkSize赋值而来的，Content-Length表示第一个片的内容长度，希望将defaultChunkSize由2MB改为4MB

理由：与JAVA-SDK保持一致，更标准（JAVA-SDK下没有定义defaultChunkSize，而是将上传body的size设置为Content-Length）

文档：https://developer.qiniu.com/kodo/api/1286/mkblk