### PR TITLE
优化CMake，增加emu_posix关于windows的条件编译命令

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ SET(PROJECT_NAME qiniu)
 #建立项目
 PROJECT(${PROJECT_NAME})
 
+if (POLICY CMP0042)
+    cmake_policy(SET CMP0042 NEW)
+endif()
+
 #添加C++11支持
 #include(CheckCXXCompilerFlag) 
 #CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)  
@@ -21,16 +25,29 @@ PROJECT(${PROJECT_NAME})
 #添加GNU99支持 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99 -g")
 
+if(APPLE)
+    set(OPENSSL_ROOT_DIR /usr/local/opt/openssl CACHE PATH "Root path to the openSSL library.")
+endif()
+find_package(OpenSSL REQUIRED)
+include_directories(${OPENSSL_INCLUDE_DIR})
+
 AUX_SOURCE_DIRECTORY(b64 DIR_SRCS_B64)
 AUX_SOURCE_DIRECTORY(cJSON DIR_SRCS_CJSON)
 AUX_SOURCE_DIRECTORY(qiniu DIR_SRCS_QINIU)
-MESSAGE(STATUS "Src file: ${DIR_SRCS}")
+
 #编译可执行程序
 #ADD_EXECUTABLE(${PROJECT_NAME} ${DIR_SRCS})
-#如果要生成动态链接库
-#ADD_LIBRARY(${PROJECT_NAME} STATIC ${DIR_SRCS_B64} ${DIR_SRCS_CJSON} ${DIR_SRCS_QINIU})
-#如果要生成动态链接库
-ADD_LIBRARY(${PROJECT_NAME} SHARED ${DIR_SRCS_B64} ${DIR_SRCS_CJSON} ${DIR_SRCS_QINIU})
 
-#添加链接库
-TARGET_LINK_LIBRARIES(${PROJECT_NAME} -lcurl -lcrypto -lssl -lm)
+set(Qiniu_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} CACHE PATH "The directory of Qiniu SDK headers.")
+set(Qiniu_LIBRARIES ${PROJECT_NAME} CACHE STRING "")
+
+if(BUILD_SHARED_LIBS)
+    #如果要生成动态链接库
+    ADD_LIBRARY(${Qiniu_LIBRARIES} SHARED ${DIR_SRCS_B64} ${DIR_SRCS_CJSON} ${DIR_SRCS_QINIU})
+    #添加链接库
+    TARGET_LINK_LIBRARIES(${Qiniu_LIBRARIES} -lcurl -lcrypto -lssl -lm)
+else()
+    #如果要生成静态链接库
+    ADD_LIBRARY(${Qiniu_LIBRARIES} STATIC ${DIR_SRCS_B64} ${DIR_SRCS_CJSON} ${DIR_SRCS_QINIU})
+    message(STATUS "Build ${Qiniu_LIBRARIES} sdk as static library.")
+endif()

--- a/qiniu/emu_posix.c
+++ b/qiniu/emu_posix.c
@@ -10,6 +10,8 @@
 #include "emu_posix.h"
 #include <sys/stat.h>
 
+#ifdef _WIN32
+
 Qiniu_Posix_Handle Qiniu_Posix_Open(const char* file, int oflag, int mode)
 {
 	Qiniu_Posix_Handle fd = CreateFileA(
@@ -87,3 +89,5 @@ unsigned _int64 Qiniu_Posix_GetTimeOfDay(void)
 	uint.u.HighPart = tv.dwHighDateTime;
 	return uint.QuadPart / 1000L;
 } // Qiniu_Posix_GetTimeOfDay
+
+#endif /* _WIN32 */

--- a/qiniu/emu_posix.h
+++ b/qiniu/emu_posix.h
@@ -9,6 +9,7 @@
 #ifndef QINIU_EMU_POSIX_H
 #define QINIU_EMU_POSIX_H
 
+#ifdef _WIN32
 #include <windows.h>
 #include <sys/types.h>
 
@@ -53,5 +54,6 @@ QINIU_DLLAPI extern unsigned _int64 Qiniu_Posix_GetTimeOfDay(void);
 #ifdef __cplusplus
 }
 #endif
+#endif /* _WIN32 */
 
 #endif /* QINIU_EMU_POSIX_H */


### PR DESCRIPTION
### 1 优化CMake指令

- 增加*Qiniu_INCLUDE_DIRS*和*Qiniu_LIBRARIES*两个输出变量。
- MacOS增加OpenSSL库的搜索路径，避免直接引用系统路径而出现权限问题。
- 依据全局*BUILD_SHARED_LIBS*变量自动选择静态库或动态库为编译目标。

### 2 emu_posix的条件编译指令

仅在windows平台上使用emu_posix。